### PR TITLE
add comps groups searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,21 @@ defer t.Close()
 
 // Use Tangy to search for RPMs, by name, that are associated to a specific repository version, returning up to the first 100 results
 versionHref := "/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
-rows, err := t.RpmRepositoryVersionPackageSearch(context.Background(), []string{versionHref}, "ninja", 100)
+rows, err := t.RpmRepositoryVersionPackageSearch(context.Background(), []string{versionHref}, "bear", 100)
+if err != nil {
+return err
+}
+
+// Use Tangy to search for RPM Package Groups, by name, that are associated to a specific repository version, returning up to the first 100 results
+versionHref := "/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
+rows, err := t.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{versionHref}, "mammals", 100)
+if err != nil {
+return err
+}
+
+// Use Tangy to search for RPM Environments, by name, that are associated to a specific repository version, returning up to the first 100 results
+versionHref := "/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
+rows, err := t.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{versionHref}, "animals", 100)
 if err != nil {
 return err
 }

--- a/example.go
+++ b/example.go
@@ -37,14 +37,43 @@ func main() {
 	}
 
 	// Use Tangy to search for RPMs, by name, that are associated to a specific repository version, returning up to the first 100 results
-	rows, err := t.RpmRepositoryVersionPackageSearch(context.Background(), []string{versionHref}, "ninja", 100)
+	rows, err := t.RpmRepositoryVersionPackageSearch(context.Background(), []string{versionHref}, "bear", 100)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	fmt.Printf("\nPackages\n==================\n")
 	for _, row := range rows {
 		fmt.Printf("\nName: %v \nSummary: %v", row.Name, row.Summary)
+	}
+	fmt.Printf("\n")
+
+	// Use Tangy to search for RPM package groups, by name, that are associated to a specific repository version, returning up to the first 100 results
+	var pkgGroups []tangy.RpmPackageGroupSearch
+	pkgGroups, err = t.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{versionHref}, "bir", 100)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("\nPackage Groups\n==================\n")
+	for _, row := range pkgGroups {
+		fmt.Printf("\nName: %v \nID: %v", row.Name, row.ID)
+	}
+	fmt.Printf("\n")
+
+	// Use Tangy to search for RPM environments, by name, that are associated to a specific repository version, returning up to the first 100 results
+	var pkgEnvs []tangy.RpmEnvironmentSearch
+	pkgEnvs, err = t.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{versionHref}, "avi", 100)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("\nEnvironments\n==================\n")
+	for _, row := range pkgEnvs {
+		fmt.Printf("\nName: %v \nID: %v", row.Name, row.ID)
 	}
 	fmt.Printf("\n")
 }
@@ -59,7 +88,7 @@ func CreateRepositoryVersion() (versionHref string, err error) {
 		DownloadPolicy: "on_demand",
 	})
 
-	domainName := "example-domain"
+	domainName := "example-domain-12231231"
 
 	// Create domain and repository, then sync repository, to create a new repository version with rpm packages
 	_, err = rpmZest.LookupOrCreateDomain(domainName)
@@ -67,7 +96,7 @@ func CreateRepositoryVersion() (versionHref string, err error) {
 		return "", err
 	}
 
-	repoHref, remoteHref, err := rpmZest.CreateRepository(domainName, "rpm modular", "https://fixtures.pulpproject.org/rpm-modular/")
+	repoHref, remoteHref, err := rpmZest.CreateRepository(domainName, "zoo", "https://rverdile.fedorapeople.org/dummy-repos/comps/repo2/")
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +111,7 @@ func CreateRepositoryVersion() (versionHref string, err error) {
 		return "", err
 	}
 
-	resp, err := rpmZest.GetRpmRepositoryByName(domainName, "rpm modular")
+	resp, err := rpmZest.GetRpmRepositoryByName(domainName, "zoo")
 	if err != nil {
 		return "", err
 	}

--- a/internal/test/integration/rpm_test.go
+++ b/internal/test/integration/rpm_test.go
@@ -17,16 +17,18 @@ import (
 
 type RpmSuite struct {
 	suite.Suite
-	client     *zestwrapper.RpmZest
-	tangy      tangy.Tangy
-	domainName string
-	remoteHref string
-	repoHref   string
+	client            *zestwrapper.RpmZest
+	tangy             tangy.Tangy
+	domainName        string
+	remoteHref        string
+	repoHref          string
+	firstVersionHref  string
+	secondVersionHref string
 }
 
-const testRepoName = "rpm modular"
-const testRepoURL = "https://jlsherrill.fedorapeople.org/fake-repos/revision/one/"
-const testRepoURLTwo = "https://jlsherrill.fedorapeople.org/fake-repos/revision/two/"
+const testRepoName = "zoo"
+const testRepoURL = "https://rverdile.fedorapeople.org/dummy-repos/comps/repo1/"
+const testRepoURLTwo = "https://rverdile.fedorapeople.org/dummy-repos/comps/repo2/"
 
 func (r *RpmSuite) CreateTestRepository(t *testing.T) {
 	domainName := RandStringBytes(10)
@@ -77,67 +79,61 @@ func TestRpmSuite(t *testing.T) {
 	r.client = &rpmZest
 	r.tangy = ta
 	r.CreateTestRepository(t)
+
+	// Get first version href
+	resp, err := r.client.GetRpmRepositoryByName(r.domainName, testRepoName)
+	require.NoError(t, err)
+	require.NotNil(t, resp.LatestVersionHref)
+	r.firstVersionHref = *resp.LatestVersionHref
+
+	// Create second repository version
+	r.UpdateTestRepository(t, testRepoURLTwo)
+	resp, err = r.client.GetRpmRepositoryByName(r.domainName, testRepoName)
+	require.NoError(t, err)
+	require.NotNil(t, resp.LatestVersionHref)
+	r.secondVersionHref = *resp.LatestVersionHref
+
 	suite.Run(t, &r)
 }
 
 func (r *RpmSuite) TestRpmRepositoryVersionPackageSearch() {
-	resp, err := r.client.GetRpmRepositoryByName(r.domainName, testRepoName)
-	require.NoError(r.T(), err)
-	firstVersionHref := resp.LatestVersionHref
-	require.NotNil(r.T(), firstVersionHref)
+	firstVersionHref := &r.firstVersionHref
+	secondVersionHref := &r.secondVersionHref
 
 	// Search first repository version
-	search, err := r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref}, "bea", 100)
+	search, err := r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref}, "peng", 100)
 	assert.NoError(r.T(), err)
-	assert.Equal(r.T(), search[0].Name, "bear")
-	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref}, "cam", 100)
+	assert.Equal(r.T(), search[0].Name, "penguin")
+	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref}, "bea", 100)
 	assert.NoError(r.T(), err)
 	assert.Empty(r.T(), search)
 
-	// Create second repository version
-	r.UpdateTestRepository(r.T(), testRepoURLTwo)
-	resp, err = r.client.GetRpmRepositoryByName(r.domainName, testRepoName)
-	require.NoError(r.T(), err)
-	secondVersionHref := resp.LatestVersionHref
-	require.NotNil(r.T(), secondVersionHref)
-
 	// Search second repository version, should have new package
+	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*secondVersionHref}, "peng", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), search[0].Name, "penguin")
+	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*secondVersionHref}, "sto", 100)
+	assert.NoError(r.T(), err)
+	assert.Empty(r.T(), search)
 	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*secondVersionHref}, "bea", 100)
 	assert.NoError(r.T(), err)
 	assert.Equal(r.T(), search[0].Name, "bear")
-	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*secondVersionHref}, "cam", 100)
-	assert.NoError(r.T(), err)
-	assert.Equal(r.T(), search[0].Name, "camel")
 
 	// Re-search the first version, should be the same
-	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref}, "bea", 100)
+	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref}, "peng", 100)
 	assert.NoError(r.T(), err)
-	assert.Equal(r.T(), search[0].Name, "bear")
-	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref}, "cam", 100)
+	assert.Equal(r.T(), search[0].Name, "penguin")
+	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref}, "bea", 100)
 	assert.NoError(r.T(), err)
 	assert.Empty(r.T(), search)
 
 	// Search both versions
-	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref, *secondVersionHref}, "a", 100)
+	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*firstVersionHref, *secondVersionHref}, "e", 100)
 	assert.NoError(r.T(), err)
-	assert.Len(r.T(), search, 2)
-	assert.Equal(r.T(), search[0].Name, "bear")
-	assert.Equal(r.T(), search[1].Name, "camel")
-
-	// Create third repository version to remove new package
-	r.UpdateTestRepository(r.T(), testRepoURL)
-	resp, err = r.client.GetRpmRepositoryByName(r.domainName, testRepoName)
-	require.NoError(r.T(), err)
-	thirdVersionHref := resp.LatestVersionHref
-	require.NotNil(r.T(), thirdVersionHref)
-
-	// Search third repository version, should not have new package
-	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*thirdVersionHref}, "bea", 100)
-	assert.NoError(r.T(), err)
-	assert.Equal(r.T(), search[0].Name, "bear")
-	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*thirdVersionHref}, "cam", 100)
-	assert.NoError(r.T(), err)
-	assert.Empty(r.T(), search)
+	assert.Len(r.T(), search, 3)
+	assert.Equal(r.T(), "bear", search[0].Name)
+	assert.Equal(r.T(), "cockateel", search[1].Name)
+	assert.Equal(r.T(), "penguin", search[2].Name)
 
 	// Test search limit
 	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{*secondVersionHref}, "a", 1)
@@ -146,6 +142,104 @@ func (r *RpmSuite) TestRpmRepositoryVersionPackageSearch() {
 
 	// Test search empty list
 	search, err = r.tangy.RpmRepositoryVersionPackageSearch(context.Background(), []string{}, "a", 1)
+	assert.NoError(r.T(), err)
+	assert.Len(r.T(), search, 0)
+}
+
+func (r *RpmSuite) TestRpmRepositoryVersionPackageGroupSearch() {
+	firstVersionHref := &r.firstVersionHref
+	secondVersionHref := &r.secondVersionHref
+
+	// Search first repository version
+	search, err := r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{*firstVersionHref}, "bir", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), search[0].Name, "birds")
+	assert.Equal(r.T(), search[0].ID, "birds")
+	assert.Equal(r.T(), search[0].Description, "birds")
+	assert.ElementsMatch(r.T(), search[0].Packages, []string{"cockateel", "penguin", "stork"})
+	search, err = r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{*firstVersionHref}, "mamm", 100)
+	assert.NoError(r.T(), err)
+	assert.Empty(r.T(), search)
+
+	// Search second repository version, should have new package and removed package
+	search, err = r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{*secondVersionHref}, "bir", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), search[0].Name, "birds")
+	assert.ElementsMatch(r.T(), search[0].Packages, []string{"cockateel", "penguin"})
+	search, err = r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{*secondVersionHref}, "mamm", 100)
+	assert.NoError(r.T(), err)
+	assert.ElementsMatch(r.T(), search[0].Packages, []string{"bear", "cat"})
+
+	// Re-search the first version, should be the same
+	search, err = r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{*firstVersionHref}, "bir", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), search[0].Name, "birds")
+	assert.ElementsMatch(r.T(), search[0].Packages, []string{"cockateel", "penguin", "stork"})
+	search, err = r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{*firstVersionHref}, "mamm", 100)
+	assert.NoError(r.T(), err)
+	assert.Empty(r.T(), search)
+
+	// Search both versions
+	search, err = r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{*firstVersionHref, *secondVersionHref}, "s", 100)
+	assert.NoError(r.T(), err)
+	assert.ElementsMatch(r.T(), search[0].Packages, []string{"cockateel", "penguin", "stork"})
+	assert.ElementsMatch(r.T(), search[1].Packages, []string{"bear", "cat"})
+
+	// Test search limit
+	search, err = r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{*firstVersionHref, *secondVersionHref}, "s", 1)
+	assert.NoError(r.T(), err)
+	assert.Len(r.T(), search, 1)
+
+	// Test search empty list
+	search, err = r.tangy.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{}, "a", 1)
+	assert.NoError(r.T(), err)
+	assert.Len(r.T(), search, 0)
+}
+
+func (r *RpmSuite) TestRpmRepositoryVersionEnvironmentSearch() {
+	firstVersionHref := &r.firstVersionHref
+	secondVersionHref := &r.secondVersionHref
+
+	// Search first repository version
+	search, err := r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{*firstVersionHref}, "avi", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), "avians", search[0].Name)
+	assert.Equal(r.T(), "avians", search[0].ID)
+	assert.Equal(r.T(), "avians", search[0].Description)
+	search, err = r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{*firstVersionHref}, "ani", 100)
+	assert.NoError(r.T(), err)
+	assert.Empty(r.T(), search)
+
+	// Search second repository version, should have new package and removed package
+	search, err = r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{*secondVersionHref}, "avi", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), "avians", search[0].Name)
+	search, err = r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{*secondVersionHref}, "ani", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), "animals", search[0].Name)
+
+	// Re-search the first version, should be the same
+	search, err = r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{*firstVersionHref}, "avi", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), search[0].Name, "avians")
+	search, err = r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{*firstVersionHref}, "ani", 100)
+	assert.NoError(r.T(), err)
+	assert.Empty(r.T(), search)
+
+	// Search both versions
+	search, err = r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{*firstVersionHref, *secondVersionHref}, "a", 100)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), 2, len(search))
+	assert.Equal(r.T(), "animals", search[0].Name)
+	assert.Equal(r.T(), "avians", search[1].Name)
+
+	// Test search limit
+	search, err = r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{*firstVersionHref, *secondVersionHref}, "s", 1)
+	assert.NoError(r.T(), err)
+	assert.Len(r.T(), search, 1)
+
+	// Test search empty list
+	search, err = r.tangy.RpmRepositoryVersionEnvironmentSearch(context.Background(), []string{}, "a", 1)
 	assert.NoError(r.T(), err)
 	assert.Len(r.T(), search, 0)
 }

--- a/pkg/tangy/interface.go
+++ b/pkg/tangy/interface.go
@@ -53,6 +53,8 @@ type tangyImpl struct {
 //go:generate mockery --name Tangy --filename tangy_mock.go --inpackage
 type Tangy interface {
 	RpmRepositoryVersionPackageSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmPackageSearch, error)
+	RpmRepositoryVersionPackageGroupSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmPackageGroupSearch, error)
+	RpmRepositoryVersionEnvironmentSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmEnvironmentSearch, error)
 	Close()
 }
 

--- a/pkg/tangy/rpm.go
+++ b/pkg/tangy/rpm.go
@@ -17,6 +17,26 @@ type RpmPackageSearch struct {
 	Summary string
 }
 
+type rpmPackageGroupSearchQueryReturn struct {
+	ID          string
+	Name        string
+	Description string
+	Packages    []map[string]any
+}
+
+type RpmPackageGroupSearch struct {
+	ID          string
+	Name        string
+	Description string
+	Packages    []string
+}
+
+type RpmEnvironmentSearch struct {
+	ID          string
+	Name        string
+	Description string
+}
+
 // RpmRepositoryVersionPackageSearch search for RPMs, by name, associated to repository hrefs, returning an amount up to limit
 func (t *tangyImpl) RpmRepositoryVersionPackageSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmPackageSearch, error) {
 	if len(hrefs) == 0 {
@@ -40,6 +60,132 @@ func (t *tangyImpl) RpmRepositoryVersionPackageSearch(ctx context.Context, hrefs
 
 	query := `SELECT DISTINCT ON (rp.name) rp.name, rp.summary
               FROM rpm_package rp WHERE rp.content_ptr_id IN (`
+
+	query = buildSearchQuery(query, search, limit, repositoryIDs, versions)
+
+	rows, err := conn.Query(context.Background(), query)
+	if err != nil {
+		return nil, err
+	}
+
+	rpms, err := pgx.CollectRows(rows, pgx.RowToStructByName[RpmPackageSearch])
+	if err != nil {
+		return nil, err
+	}
+	return rpms, nil
+}
+
+// RpmRepositoryVersionPackageGroupSearch search for RPM Package Groups, by name, associated to repository hrefs, returning an amount up to limit
+func (t *tangyImpl) RpmRepositoryVersionPackageGroupSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmPackageGroupSearch, error) {
+	if len(hrefs) == 0 {
+		return []RpmPackageGroupSearch{}, nil
+	}
+
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Release()
+
+	if limit == 0 {
+		limit = DefaultLimit
+	}
+
+	repositoryIDs, versions, err := parseRepositoryVersionHrefs(hrefs)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing repository version hrefs: %w", err)
+	}
+
+	query := `SELECT DISTINCT ON (rp.name, rp.id, rp.packages) rp.name, rp.id, rp.description, rp.packages
+              FROM rpm_packagegroup rp WHERE rp.content_ptr_id IN (
+			`
+	query = buildSearchQuery(query, search, limit, repositoryIDs, versions)
+
+	rows, err := conn.Query(context.Background(), query)
+	if err != nil {
+		return nil, err
+	}
+	rpms, err := pgx.CollectRows(rows, pgx.RowToStructByName[rpmPackageGroupSearchQueryReturn])
+	if err != nil {
+		return nil, err
+	}
+
+	var pkgGroupMap = make(map[string]RpmPackageGroupSearch, 0)
+	for _, rpm := range rpms {
+		nameId := rpm.Name + rpm.ID
+		pkgGroup, groupExists := pkgGroupMap[nameId]
+		if groupExists {
+			newList, err := parsePackages(rpm.Packages)
+			if err != nil {
+				return nil, err
+			}
+			pkgGroup.Packages = unionSlices[string](newList, pkgGroupMap[nameId].Packages)
+		} else {
+			pkgGroup.ID = rpm.ID
+			pkgGroup.Name = rpm.Name
+			pkgGroup.Description = rpm.Description
+			pkgGroup.Packages, err = parsePackages(rpm.Packages)
+			if err != nil {
+				return nil, err
+			}
+		}
+		pkgGroupMap[nameId] = RpmPackageGroupSearch{
+			ID:          pkgGroup.ID,
+			Name:        pkgGroup.Name,
+			Description: pkgGroup.Description,
+			Packages:    pkgGroup.Packages,
+		}
+	}
+
+	var searchResult []RpmPackageGroupSearch
+	for _, pkgGroup := range pkgGroupMap {
+		searchResult = append(searchResult, pkgGroup)
+	}
+
+	return searchResult, nil
+}
+
+// RpmRepositoryVersionEnvironmentSearch search for RPM Environments, by name, associated to repository hrefs, returning an amount up to limit
+func (t *tangyImpl) RpmRepositoryVersionEnvironmentSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmEnvironmentSearch, error) {
+	if len(hrefs) == 0 {
+		return []RpmEnvironmentSearch{}, nil
+	}
+
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Release()
+
+	if limit == 0 {
+		limit = DefaultLimit
+	}
+
+	repositoryIDs, versions, err := parseRepositoryVersionHrefs(hrefs)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing repository version hrefs: %w", err)
+	}
+
+	query := `SELECT DISTINCT ON (rp.name, rp.id) rp.name, rp.id, rp.description
+              FROM rpm_packageenvironment rp WHERE rp.content_ptr_id IN (
+			`
+	query = buildSearchQuery(query, search, limit, repositoryIDs, versions)
+
+	rows, err := conn.Query(context.Background(), query)
+	if err != nil {
+		return nil, err
+	}
+	rpms, err := pgx.CollectRows(rows, pgx.RowToStructByName[RpmEnvironmentSearch])
+	if err != nil {
+		return nil, err
+	}
+
+	return rpms, nil
+}
+
+// buildSearchQuery builds search query for rpm package, package group, and environment search by name
+func buildSearchQuery(queryFragment string, search string, limit int, repositoryIDs []string, versions []int) string {
+	query := queryFragment
 	for i := 0; i < len(repositoryIDs); i++ {
 		id := repositoryIDs[i]
 		ver := versions[i]
@@ -62,15 +208,7 @@ func (t *tangyImpl) RpmRepositoryVersionPackageSearch(ctx context.Context, hrefs
 
 		query += "UNION"
 	}
-	rows, err := conn.Query(context.Background(), query)
-	if err != nil {
-		return nil, err
-	}
-	rpms, err := pgx.CollectRows(rows, pgx.RowToStructByName[RpmPackageSearch])
-	if err != nil {
-		return nil, err
-	}
-	return rpms, nil
+	return query
 }
 
 func parseRepositoryVersionHrefs(hrefs []string) (repositoryIDs []string, versions []int, err error) {
@@ -97,4 +235,29 @@ func parseRepositoryVersionHrefs(hrefs []string) (repositoryIDs []string, versio
 		versions = append(versions, ver)
 	}
 	return
+}
+
+func parsePackages(pulpPackageList []map[string]any) ([]string, error) {
+	var packageList []string
+	for _, pkg := range pulpPackageList {
+		pkgName, ok := pkg["name"].(string)
+		if !ok {
+			return nil, fmt.Errorf("name invalid for package in package list")
+		}
+		packageList = append(packageList, pkgName)
+	}
+	return packageList, nil
+}
+
+func unionSlices[T comparable](a []T, b []T) []T {
+	var mapSet = make(map[T]bool, 0)
+	for _, i := range a {
+		mapSet[i] = true
+	}
+	for _, i := range b {
+		if _, ok := mapSet[i]; !ok {
+			a = append(a, i)
+		}
+	}
+	return a
 }

--- a/pkg/tangy/tangy_mock.go
+++ b/pkg/tangy/tangy_mock.go
@@ -18,6 +18,58 @@ func (_m *MockTangy) Close() {
 	_m.Called()
 }
 
+// RpmRepositoryVersionEnvironmentSearch provides a mock function with given fields: ctx, hrefs, search, limit
+func (_m *MockTangy) RpmRepositoryVersionEnvironmentSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmEnvironmentSearch, error) {
+	ret := _m.Called(ctx, hrefs, search, limit)
+
+	var r0 []RpmEnvironmentSearch
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []string, string, int) ([]RpmEnvironmentSearch, error)); ok {
+		return rf(ctx, hrefs, search, limit)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []string, string, int) []RpmEnvironmentSearch); ok {
+		r0 = rf(ctx, hrefs, search, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]RpmEnvironmentSearch)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []string, string, int) error); ok {
+		r1 = rf(ctx, hrefs, search, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RpmRepositoryVersionPackageGroupSearch provides a mock function with given fields: ctx, hrefs, search, limit
+func (_m *MockTangy) RpmRepositoryVersionPackageGroupSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmPackageGroupSearch, error) {
+	ret := _m.Called(ctx, hrefs, search, limit)
+
+	var r0 []RpmPackageGroupSearch
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []string, string, int) ([]RpmPackageGroupSearch, error)); ok {
+		return rf(ctx, hrefs, search, limit)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []string, string, int) []RpmPackageGroupSearch); ok {
+		r0 = rf(ctx, hrefs, search, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]RpmPackageGroupSearch)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []string, string, int) error); ok {
+		r1 = rf(ctx, hrefs, search, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RpmRepositoryVersionPackageSearch provides a mock function with given fields: ctx, hrefs, search, limit
 func (_m *MockTangy) RpmRepositoryVersionPackageSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmPackageSearch, error) {
 	ret := _m.Called(ctx, hrefs, search, limit)


### PR DESCRIPTION
Adds two new methods to the Tangy interface

- `RpmRepositoryVersionPackageGroupSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmPackageGroupSearch, error)`
  - Returns list of package groups (with ID, Name, Description, and Package list) in repository version, sorted by name. Package lists for overlapping ID+Name will be combined and de-duplicated.
- `RpmRepositoryVersionEnvironmentSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmEnvironmentSearch, error)`
  - Returns list of environments (with ID, Name, Description) in repository version, sorted by name, and de-duplicated by ID+Name.