### PR TITLE
update to new pulp href

### DIFF
--- a/.github/workflows/tang-actions.yaml
+++ b/.github/workflows/tang-actions.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Wait for pulp
         run: |
           docker run --network=host --rm -v ${PWD}:/local curlimages/curl  \
-          curl --retry-all-errors --fail --retry-delay 10 --retry 32 --retry-max-time 240 http://localhost:8087/pulp/default/api/v3/repositories/rpm/rpm/  -u admin:password
+          curl --retry-all-errors --fail --retry-delay 10 --retry 32 --retry-max-time 240 http://localhost:8087/api/pulp/default/api/v3/repositories/rpm/rpm/  -u admin:password
           sleep 30
       - name: integration tests
         run: |

--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ if err != nil {
 defer t.Close()
 
 // Use Tangy to search for RPMs, by name, that are associated to a specific repository version, returning up to the first 100 results
-versionHref := "/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
+versionHref := "/api/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
 rows, err := t.RpmRepositoryVersionPackageSearch(context.Background(), []string{versionHref}, "bear", 100)
 if err != nil {
 return err
 }
 
 // Use Tangy to search for RPM Package Groups, by name, that are associated to a specific repository version, returning up to the first 100 results
-versionHref := "/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
+versionHref := "/api/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
 rows, err := t.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{versionHref}, "mammals", 100)
 if err != nil {
 return err
 }
 
 // Use Tangy to search for RPM Environments, by name, that are associated to a specific repository version, returning up to the first 100 results
-versionHref := "/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
+versionHref := "/api/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/"
 rows, err := t.RpmRepositoryVersionPackageGroupSearch(context.Background(), []string{versionHref}, "animals", 100)
 if err != nil {
 return err

--- a/compose_files/pulp/docker-compose.yml
+++ b/compose_files/pulp/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       POSTGRES_SERVICE_HOST: postgres
       PULP_ADMIN_PASSWORD: password
       PULP_DOMAIN_ENABLED: "true"
+      PULP_API_ROOT: /api/pulp/
     restart: always
 
   pulp_content:
@@ -91,6 +92,7 @@ services:
       POSTGRES_SERVICE_PORT: 5432
       POSTGRES_SERVICE_HOST: postgres
       PULP_DOMAIN_ENABLED: "true"
+      PULP_API_ROOT: /api/pulp/
     restart: always
 
   pulp_web:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/content-services/tang
 go 1.20
 
 require (
-	github.com/content-services/zest/release/v2023 v2023.11.1701177874
+	github.com/content-services/zest/release/v2024 v2024.1.1706018763
 	github.com/google/uuid v1.4.0
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb
 	github.com/jackc/pgx/v5 v5.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/content-services/zest/release/v2023 v2023.11.1701177874 h1:yC5uRkU78UtVe3oTn0pRwT9KBd9b4SBAfQ9QTargCqg=
-github.com/content-services/zest/release/v2023 v2023.11.1701177874/go.mod h1:9pesd98rUBOqg1z2UL65NA1+zZQRcFJY3VIdimAJxL8=
+github.com/content-services/zest/release/v2024 v2024.1.1706018763 h1:TrFMpNk1SaTgxmdh7PggnEGmAZZoKS7oOhqSeNlkxf0=
+github.com/content-services/zest/release/v2024 v2024.1.1706018763/go.mod h1:UwNlzoIpFWKjR3yPnm+l4GtShPYLhWy9Rt+jmFM5W/U=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/zestwrapper/rpm.go
+++ b/internal/zestwrapper/rpm.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/content-services/tang/internal/config"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"golang.org/x/exp/slices"
 )
 

--- a/pkg/tangy/rpm.go
+++ b/pkg/tangy/rpm.go
@@ -212,14 +212,14 @@ func buildSearchQuery(queryFragment string, search string, limit int, repository
 }
 
 func parseRepositoryVersionHrefs(hrefs []string) (repositoryIDs []string, versions []int, err error) {
-	// /pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/
+	// /api/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/
 	for _, href := range hrefs {
 		splitHref := strings.Split(href, "/")
 		if len(splitHref) < 10 {
 			return nil, nil, fmt.Errorf("%v is not a valid href", splitHref)
 		}
-		id := splitHref[8]
-		num := splitHref[10]
+		id := splitHref[9]
+		num := splitHref[11]
 
 		_, err = uuid.Parse(id)
 		if err != nil {


### PR DESCRIPTION
Changes to pulp href, where api is preprended to the path, breaks the href parsing function. This shifts the indexes over one to account for that.

And update zest version