### PR TITLE
Fixes 4740: Change base query to use inner joins

### DIFF
--- a/compose_files/pulp/docker-compose.yml
+++ b/compose_files/pulp/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       postgres:
         condition: service_healthy
     command: pulpcore-manager migrate --noinput
+    restart: on-failure
     volumes:
       - "./assets/settings.py:/etc/pulp/settings.py:z"
       - "./assets/certs:/etc/pulp/certs:z"


### PR DESCRIPTION
I saw improvements with package queries by around 2x.  Errata query times were very similar to before.

To test:

Load a bunch of repos and sync them (make repos-import && go run cmd/external-repos/main.go nightly-jobs).  You might add some large fedora repos too.


in content-sources-backend go.mod add this under `go 1.23`:

```
replace github.com/content-services/tang => /home/jlsherri/git/tang
```

(replace with path to your checkout).
```
go get ./...
```

(Note that when switching branches, or modifying code in tang, you must  `rm  release/content-sources`  before you `make run` to pick up the changes

* Confirm that listing rpms and advisories for templates works
* compare the counts before and after this change
* To see a time difference, you can enable query logging in postgres:
```
psql --host localhost -U pulp
ALTER SYSTEM SET log_min_duration_statement = 25;
select pg_reload_conf();
```

Now after fetching some set of content, you can run ```podman logs --tail 1000 cs_postgres_1``` and see the time it takes:

```
LOG:  duration: 208.538 ms
```

You can switch back and forth between main and this branch to see the changes.  You may want to compare the times (should be about half).

