### PR TITLE
Add Python package listing and distribution queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,36 @@ rows, err := t.RpmRepositoryVersionPackageGroupSearch(context.Background(), []st
 if err != nil {
   return err
 }
+
+// Use Tangy to list Python packages from the latest version of a repository, grouped by name_normalized
+repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+packages, err := t.PythonPackageList(context.Background(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 10})
+if err != nil {
+  return err
+}
+
+// Use Tangy to list distribution files for a specific Python package version (filter by name_normalized)
+distributions, err := t.PythonDistributionList(context.Background(), repositoryHref, "shelf-reader", "0.1", tangy.PageOptions{Offset: 0, Limit: 10})
+if err != nil {
+  return err
+}
 ```
-See example.go for a complete example.
+See example.go for a complete RPM example.
+
+### Python packages
+
+Python support queries the `python_pythonpackagecontent` table. Each row is one installable distribution file (wheel, sdist, etc.).
+
+- **`PythonPackageList`** — lists packages in the latest repository version, grouped by `name_normalized`, with all versions and `latest_versions` (most recent `pulp_created` per version). Pagination is done in SQL.
+- **`PythonDistributionList`** — lists distribution files for a given `name_normalized` and `version`. Pagination is done in SQL.
+
+Repository href format:
+
+```
+/api/pulp/{domain}/api/v3/repositories/python/python/{uuid}/
+```
+
+`PythonDistributionList` filters by `name_normalized` (PEP 503), not the display `name`.
 
 ## Developing
 To develop for tangy, there are a few more things to know.
@@ -79,6 +107,41 @@ The default values provided in config.yaml.example will work with this server.
 
 #### Clean container volumes
 `make compose-clean`
+
+### Testing
+
+#### Unit tests
+
+Unit tests live under `pkg/tangy/` and do not require a running Pulp instance (they cover helpers, response assembly, and the `MockTangy` interface).
+
+```bash
+go test ./pkg/tangy/... -v
+```
+
+#### Integration tests
+
+Integration tests live under `internal/test/integration/`. They need a running Pulp stack and a `configs/config.yaml` that points at it (see `configs/config.yaml.example`).
+
+1. Start Pulp:
+
+```bash
+make compose-up
+```
+
+2. Run all integration tests:
+
+```bash
+make test-integration
+```
+
+Or run a specific suite:
+
+```bash
+CONFIG_PATH="$(pwd)/configs/" go test ./internal/test/integration/ -run TestPythonSuite -v
+CONFIG_PATH="$(pwd)/configs/" go test ./internal/test/integration/ -run TestRpmSuite -v
+```
+
+The Python integration test syncs `shelf-reader` from PyPI into a random domain via the Pulp API, then asserts tangy can read it from the database. Test data is left in the database after a run; use `make compose-clean` to wipe volumes and start fresh.
 
 ### Mocking
 Tangy also exports a mock interface you can regenerate using the [mockery](https://github.com/vektra/mockery) tool.

--- a/internal/test/integration/python_test.go
+++ b/internal/test/integration/python_test.go
@@ -1,0 +1,179 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/content-services/tang/internal/config"
+	"github.com/content-services/tang/internal/zestwrapper"
+	"github.com/content-services/tang/pkg/tangy"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testPythonRepoName = "shelf-reader-fixture"
+	testPythonRepoURL  = "https://pypi.org/"
+	testPythonIncludes = "shelf-reader"
+)
+
+type PythonSuite struct {
+	suite.Suite
+	client         *zestwrapper.PythonZest
+	tangy          tangy.Tangy
+	domainName     string
+	repositoryHref string
+}
+
+func (p *PythonSuite) createTestRepository(t *testing.T) {
+	_, err := p.client.LookupOrCreateDomain(p.domainName)
+	require.NoError(t, err)
+
+	repoHref, remoteHref, err := p.client.CreateRepository(
+		p.domainName,
+		testPythonRepoName,
+		testPythonRepoURL,
+		[]string{testPythonIncludes},
+	)
+	require.NoError(t, err)
+
+	syncTask, err := p.client.SyncPythonRepository(repoHref, remoteHref)
+	require.NoError(t, err)
+
+	_, err = p.client.PollTask(syncTask)
+	require.NoError(t, err)
+
+	p.repositoryHref = repoHref
+}
+
+func TestPythonSuite(t *testing.T) {
+	s := config.Get().Server
+	pythonZest := zestwrapper.NewPythonZest(context.Background(), s)
+
+	dbConfig := config.Get().Database
+	ta, err := tangy.New(tangy.Database{
+		Name:     dbConfig.Name,
+		Host:     dbConfig.Host,
+		Port:     dbConfig.Port,
+		User:     dbConfig.User,
+		Password: dbConfig.Password,
+	}, tangy.Logger{Enabled: true, Logger: &log.Logger, LogLevel: zerolog.LevelDebugValue})
+	require.NoError(t, err)
+	t.Cleanup(ta.Close)
+
+	p := PythonSuite{}
+	p.client = &pythonZest
+	p.tangy = ta
+	p.domainName = RandStringBytes(10)
+
+	p.createTestRepository(t)
+
+	suite.Run(t, &p)
+}
+
+func (p *PythonSuite) TestPythonPackageList() {
+	response, err := p.tangy.PythonPackageList(context.Background(), p.repositoryHref, tangy.PageOptions{
+		Offset: 0,
+		Limit:  10,
+	})
+	require.NoError(p.T(), err)
+	require.NotEmpty(p.T(), response.Results)
+	assert.Equal(p.T(), 1, response.Total)
+
+	pkg := response.Results[0]
+	assert.Equal(p.T(), "shelf-reader", pkg.NameNormalized)
+	assert.Contains(p.T(), pkg.Versions, "0.1")
+	require.NotEmpty(p.T(), pkg.LatestVersions)
+
+	foundVersion := false
+	for _, latest := range pkg.LatestVersions {
+		if latest.Version == "0.1" {
+			foundVersion = true
+			assert.NotEmpty(p.T(), latest.CreatedAt)
+		}
+	}
+	assert.True(p.T(), foundVersion)
+}
+
+func (p *PythonSuite) TestPythonPackageListPagination() {
+	response, err := p.tangy.PythonPackageList(context.Background(), p.repositoryHref, tangy.PageOptions{
+		Offset: 0,
+		Limit:  1,
+	})
+	require.NoError(p.T(), err)
+	assert.Len(p.T(), response.Results, 1)
+	assert.Equal(p.T(), 1, response.Total)
+	assert.Equal(p.T(), 1, response.Limit)
+
+	response, err = p.tangy.PythonPackageList(context.Background(), p.repositoryHref, tangy.PageOptions{
+		Offset: 1,
+		Limit:  1,
+	})
+	require.NoError(p.T(), err)
+	assert.Empty(p.T(), response.Results)
+	assert.Equal(p.T(), 1, response.Total)
+}
+
+func (p *PythonSuite) TestPythonPackageListEmptyHref() {
+	response, err := p.tangy.PythonPackageList(context.Background(), "", tangy.PageOptions{Limit: 10})
+	require.NoError(p.T(), err)
+	assert.Empty(p.T(), response.Results)
+	assert.Zero(p.T(), response.Total)
+}
+
+func (p *PythonSuite) TestPythonDistributionList() {
+	response, err := p.tangy.PythonDistributionList(
+		context.Background(),
+		p.repositoryHref,
+		"shelf-reader",
+		"0.1",
+		tangy.PageOptions{Offset: 0, Limit: 10},
+	)
+	require.NoError(p.T(), err)
+	require.NotEmpty(p.T(), response.Results)
+	assert.GreaterOrEqual(p.T(), response.Total, 1)
+	assert.Equal(p.T(), 10, response.Limit)
+
+	for _, dist := range response.Results {
+		assert.Equal(p.T(), "shelf-reader", dist.NameNormalized)
+		assert.Equal(p.T(), "0.1", dist.Version)
+		assert.NotEmpty(p.T(), dist.Filename)
+		assert.NotEmpty(p.T(), dist.PackageType)
+		assert.NotEmpty(p.T(), dist.Sha256)
+		assert.NotZero(p.T(), dist.Size)
+		assert.NotEmpty(p.T(), dist.CreatedAt)
+	}
+
+	packageTypes := make(map[string]struct{})
+	for _, dist := range response.Results {
+		packageTypes[dist.PackageType] = struct{}{}
+	}
+	assert.NotEmpty(p.T(), packageTypes)
+}
+
+func (p *PythonSuite) TestPythonDistributionListPagination() {
+	response, err := p.tangy.PythonDistributionList(
+		context.Background(),
+		p.repositoryHref,
+		"shelf-reader",
+		"0.1",
+		tangy.PageOptions{Offset: 0, Limit: 1},
+	)
+	require.NoError(p.T(), err)
+	assert.Len(p.T(), response.Results, 1)
+	assert.GreaterOrEqual(p.T(), response.Total, 1)
+
+	response, err = p.tangy.PythonDistributionList(
+		context.Background(),
+		p.repositoryHref,
+		"shelf-reader",
+		"0.1",
+		tangy.PageOptions{Offset: 100, Limit: 10},
+	)
+	require.NoError(p.T(), err)
+	assert.Empty(p.T(), response.Results)
+	assert.GreaterOrEqual(p.T(), response.Total, 1)
+}

--- a/internal/zestwrapper/python.go
+++ b/internal/zestwrapper/python.go
@@ -1,0 +1,141 @@
+package zestwrapper
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/content-services/tang/internal/config"
+	zest "github.com/content-services/zest/release/v2024"
+)
+
+func NewPythonZest(ctx context.Context, server config.Server) PythonZest {
+	ctx2 := context.WithValue(ctx, zest.ContextServerIndex, 0)
+	timeout := 120 * time.Second
+	transport := &http.Transport{ResponseHeaderTimeout: timeout}
+	httpClient := http.Client{Transport: transport, Timeout: timeout}
+
+	pulpConfig := zest.NewConfiguration()
+	pulpConfig.HTTPClient = &httpClient
+	pulpConfig.Servers = zest.ServerConfigurations{zest.ServerConfiguration{
+		URL: server.Url,
+	}}
+	ctx2 = context.WithValue(ctx2, zest.ContextBasicAuth, zest.BasicAuth{
+		UserName: server.Username,
+		Password: server.Password,
+	})
+
+	return PythonZest{
+		client: zest.NewAPIClient(pulpConfig),
+		ctx:    ctx2,
+	}
+}
+
+type PythonZest struct {
+	client *zest.APIClient
+	ctx    context.Context
+}
+
+func (p *PythonZest) LookupOrCreateDomain(name string) (string, error) {
+	d, err := p.LookupDomain(name)
+	if err != nil {
+		return "", err
+	}
+	if d != "" {
+		return d, nil
+	}
+
+	localStorage := zest.STORAGECLASSENUM_PULPCORE_APP_MODELS_STORAGE_FILE_SYSTEM
+	domain := *zest.NewDomain(name, localStorage, map[string]interface{}{
+		"location": fmt.Sprintf("/var/lib/pulp/%v/", name),
+	})
+	domainResp, resp, err := p.client.DomainsAPI.DomainsCreate(p.ctx, DefaultDomain).Domain(domain).Execute()
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+	return *domainResp.PulpHref, nil
+}
+
+func (p *PythonZest) LookupDomain(name string) (string, error) {
+	list, resp, err := p.client.DomainsAPI.DomainsList(p.ctx, DefaultDomain).Name(name).Execute()
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if len(list.Results) == 0 {
+		return "", nil
+	}
+	if list.Results[0].PulpHref == nil {
+		return "", fmt.Errorf("unexpectedly got a nil href for domain %v", name)
+	}
+	return *list.Results[0].PulpHref, nil
+}
+
+func (p *PythonZest) CreateRepository(domain, name, url string, includes []string) (repoHref string, remoteHref string, err error) {
+	pythonRemote := zest.NewPythonPythonRemote(name, url)
+	policy := zest.POLICY692ENUM_IMMEDIATE
+	pythonRemote.Policy = &policy
+	pythonRemote.Includes = includes
+
+	remoteResponse, httpResp, err := p.client.RemotesPythonAPI.RemotesPythonPythonCreate(p.ctx, domain).
+		PythonPythonRemote(*pythonRemote).Execute()
+	if err != nil {
+		return "", "", err
+	}
+	defer httpResp.Body.Close()
+
+	pythonRepository := zest.NewPythonPythonRepository(name)
+	if remoteResponse.PulpHref != nil {
+		pythonRepository.SetRemote(*remoteResponse.PulpHref)
+	}
+
+	repoResponse, httpResp, err := p.client.RepositoriesPythonAPI.RepositoriesPythonPythonCreate(p.ctx, domain).
+		PythonPythonRepository(*pythonRepository).Execute()
+	if err != nil {
+		return "", "", err
+	}
+	defer httpResp.Body.Close()
+
+	return *repoResponse.PulpHref, *remoteResponse.PulpHref, nil
+}
+
+func (p *PythonZest) SyncPythonRepository(repoHref, remoteHref string) (string, error) {
+	syncURL := zest.NewRepositorySyncURL()
+	syncURL.SetRemote(remoteHref)
+	mirror := true
+	syncURL.SetMirror(mirror)
+
+	resp, httpResp, err := p.client.RepositoriesPythonAPI.RepositoriesPythonPythonSync(p.ctx, repoHref).
+		RepositorySyncURL(*syncURL).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+	return resp.Task, nil
+}
+
+func (p *PythonZest) PollTask(taskHref string) (*zest.TaskResponse, error) {
+	rpmZest := RpmZest{client: p.client, ctx: p.ctx}
+	return rpmZest.PollTask(taskHref)
+}
+
+func (p *PythonZest) GetPythonRepositoryByName(domain, name string) (*zest.PythonPythonRepositoryResponse, error) {
+	resp, httpResp, err := p.client.RepositoriesPythonAPI.RepositoriesPythonPythonList(p.ctx, domain).Name(name).Execute()
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	results := resp.GetResults()
+	if len(results) > 0 {
+		return &results[0], nil
+	}
+	return nil, nil
+}

--- a/internal/zestwrapper/rpm.go
+++ b/internal/zestwrapper/rpm.go
@@ -102,6 +102,7 @@ func (r *RpmZest) CreateRepository(domain, name, url string) (repoHref string, r
 	defer httpResp.Body.Close()
 
 	rpmRpmRepository := *zest.NewRpmRpmRepository(name)
+	rpmRpmRepository.PackageSigningFingerprint = nil
 	if remoteResponse.PulpHref != nil {
 		rpmRpmRepository.SetRemote(*remoteResponse.PulpHref)
 	}

--- a/pkg/tangy/interface.go
+++ b/pkg/tangy/interface.go
@@ -65,6 +65,8 @@ type Tangy interface {
 	RpmRepositoryVersionPackageList(ctx context.Context, hrefs []string, filterOpts RpmListFilters, pageOpts PageOptions) ([]RpmListItem, int, error)
 	RpmRepositoryVersionModuleStreamsList(ctx context.Context, hrefs []string, filterOpts ModuleStreamListFilters, sortBy string) ([]ModuleStreams, error)
 	RpmRepositoryVersionErrataList(ctx context.Context, hrefs []string, filterOpts ErrataListFilters, pageOpts PageOptions) ([]ErrataListItem, int, error)
+	PythonPackageList(ctx context.Context, repositoryHref string, pageOpts PageOptions) (PythonPackageListResponse, error)
+	PythonDistributionList(ctx context.Context, repositoryHref, nameNormalized, version string, pageOpts PageOptions) (PythonDistributionListResponse, error)
 	Close()
 }
 

--- a/pkg/tangy/python.go
+++ b/pkg/tangy/python.go
@@ -1,0 +1,331 @@
+package tangy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PythonVersionInfo struct {
+	Version   string `json:"version"`
+	CreatedAt string `json:"created_at"`
+}
+
+type PythonPackageListItem struct {
+	Name           string              `json:"name"`
+	NameNormalized string              `json:"name_normalized"`
+	Versions       []string            `json:"versions"`
+	LatestVersions []PythonVersionInfo `json:"latest_versions"`
+}
+
+type PythonPackageListResponse struct {
+	Results []PythonPackageListItem `json:"results"`
+	Total   int                     `json:"total"`
+	Limit   int                     `json:"limit"`
+	Offset  int                     `json:"offset"`
+}
+
+type PythonDistributionListItem struct {
+	Name           string `json:"name"`
+	NameNormalized string `json:"name_normalized"`
+	Version        string `json:"version"`
+	Filename       string `json:"filename"`
+	PackageType    string `json:"packagetype"`
+	PythonVersion  string `json:"python_version"`
+	Sha256         string `json:"sha256"`
+	Size           int64  `json:"size"`
+	CreatedAt      string `json:"created_at"`
+}
+
+type PythonDistributionListResponse struct {
+	Results []PythonDistributionListItem `json:"results"`
+	Total   int                          `json:"total"`
+	Limit   int                          `json:"limit"`
+	Offset  int                          `json:"offset"`
+}
+
+type pythonPackageVersionRow struct {
+	NameNormalized string
+	Name           string
+	Version        string
+	CreatedAt      time.Time
+}
+
+type pythonDistributionRow struct {
+	Name           string
+	NameNormalized string
+	Version        string
+	Filename       string
+	PackageType    string
+	PythonVersion  string
+	Sha256         string
+	Size           int64
+	CreatedAt      time.Time
+}
+
+// PythonPackageList lists Python packages from the latest version of a repository,
+// grouped by name_normalized with SQL-level pagination.
+func (t *tangyImpl) PythonPackageList(ctx context.Context, repositoryHref string, pageOpts PageOptions) (PythonPackageListResponse, error) {
+	if repositoryHref == "" {
+		return PythonPackageListResponse{}, nil
+	}
+
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return PythonPackageListResponse{}, err
+	}
+	defer conn.Release()
+
+	if pageOpts.Limit == 0 {
+		pageOpts.Limit = DefaultLimit
+	}
+
+	repoUUID, err := parsePythonRepositoryHref(repositoryHref)
+	if err != nil {
+		return PythonPackageListResponse{}, fmt.Errorf("error parsing repository href: %w", err)
+	}
+
+	latestVersion, err := getLatestPythonRepositoryVersion(ctx, conn, repoUUID)
+	if err != nil {
+		return PythonPackageListResponse{}, fmt.Errorf("error getting latest repository version: %w", err)
+	}
+
+	repoVerMap := []ParsedRepoVersion{{
+		RepositoryUUID: repoUUID,
+		Version:        latestVersion,
+	}}
+
+	args := pgx.NamedArgs{
+		"limit":  pageOpts.Limit,
+		"offset": pageOpts.Offset,
+	}
+	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
+	if err != nil {
+		return PythonPackageListResponse{}, err
+	}
+
+	countQuery := `
+		SELECT COUNT(DISTINCT rp.name_normalized)
+		FROM python_pythonpackagecontent rp
+	` + innerUnion
+
+	var countTotal int
+	err = conn.QueryRow(ctx, countQuery, args).Scan(&countTotal)
+	if err != nil {
+		return PythonPackageListResponse{}, err
+	}
+
+	query := `
+		WITH filtered AS (
+			SELECT rp.name_normalized, rp.name, rp.version, cc.pulp_created
+			FROM python_pythonpackagecontent rp
+			INNER JOIN core_content cc ON rp.content_ptr_id = cc.pulp_id
+	` + innerUnion + `
+		),
+		package_versions AS (
+			SELECT name_normalized, MIN(name) AS name, version, MAX(pulp_created) AS created_at
+			FROM filtered
+			GROUP BY name_normalized, version
+		),
+		paginated_packages AS (
+			SELECT name_normalized, MIN(name) AS name
+			FROM package_versions
+			GROUP BY name_normalized
+			ORDER BY name_normalized
+			LIMIT @limit OFFSET @offset
+		)
+		SELECT pv.name_normalized, pv.name, pv.version, pv.created_at
+		FROM package_versions pv
+		INNER JOIN paginated_packages pp ON pv.name_normalized = pp.name_normalized
+		ORDER BY pv.name_normalized, pv.version`
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return PythonPackageListResponse{}, err
+	}
+
+	versionRows, err := pgx.CollectRows(rows, pgx.RowToStructByName[pythonPackageVersionRow])
+	if err != nil {
+		return PythonPackageListResponse{}, err
+	}
+
+	return PythonPackageListResponse{
+		Results: assemblePythonPackageListFromRows(versionRows),
+		Total:   countTotal,
+		Limit:   pageOpts.Limit,
+		Offset:  pageOpts.Offset,
+	}, nil
+}
+
+// PythonDistributionList lists all distribution files for a specific package name and version
+// from the latest version of a repository. The name filter uses name_normalized (PEP 503).
+func (t *tangyImpl) PythonDistributionList(ctx context.Context, repositoryHref, nameNormalized, version string, pageOpts PageOptions) (PythonDistributionListResponse, error) {
+	if repositoryHref == "" {
+		return PythonDistributionListResponse{}, nil
+	}
+
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return PythonDistributionListResponse{}, err
+	}
+	defer conn.Release()
+
+	if pageOpts.Limit == 0 {
+		pageOpts.Limit = DefaultLimit
+	}
+
+	repoUUID, err := parsePythonRepositoryHref(repositoryHref)
+	if err != nil {
+		return PythonDistributionListResponse{}, fmt.Errorf("error parsing repository href: %w", err)
+	}
+
+	latestVersion, err := getLatestPythonRepositoryVersion(ctx, conn, repoUUID)
+	if err != nil {
+		return PythonDistributionListResponse{}, fmt.Errorf("error getting latest repository version: %w", err)
+	}
+
+	repoVerMap := []ParsedRepoVersion{{
+		RepositoryUUID: repoUUID,
+		Version:        latestVersion,
+	}}
+
+	args := pgx.NamedArgs{
+		"name_normalized": nameNormalized,
+		"version":         version,
+		"limit":           pageOpts.Limit,
+		"offset":          pageOpts.Offset,
+	}
+	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
+	if err != nil {
+		return PythonDistributionListResponse{}, err
+	}
+
+	countQuery := `
+		SELECT COUNT(*)
+		FROM python_pythonpackagecontent rp
+	` + innerUnion + `
+		AND rp.name_normalized = @name_normalized
+		AND rp.version = @version`
+
+	var countTotal int
+	err = conn.QueryRow(ctx, countQuery, args).Scan(&countTotal)
+	if err != nil {
+		return PythonDistributionListResponse{}, err
+	}
+
+	query := `
+		SELECT rp.name, rp.name_normalized, rp.version, rp.filename, rp.packagetype,
+		       rp.python_version, rp.sha256, rp.size, cc.pulp_created AS created_at
+		FROM python_pythonpackagecontent rp
+		INNER JOIN core_content cc ON rp.content_ptr_id = cc.pulp_id
+	` + innerUnion + `
+		AND rp.name_normalized = @name_normalized
+		AND rp.version = @version
+		ORDER BY cc.pulp_created DESC
+		LIMIT @limit OFFSET @offset`
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return PythonDistributionListResponse{}, err
+	}
+
+	distributions, err := pgx.CollectRows(rows, pgx.RowToStructByName[pythonDistributionRow])
+	if err != nil {
+		return PythonDistributionListResponse{}, err
+	}
+
+	results := make([]PythonDistributionListItem, len(distributions))
+	for i, dist := range distributions {
+		results[i] = PythonDistributionListItem{
+			Name:           dist.Name,
+			NameNormalized: dist.NameNormalized,
+			Version:        dist.Version,
+			Filename:       dist.Filename,
+			PackageType:    dist.PackageType,
+			PythonVersion:  dist.PythonVersion,
+			Sha256:         dist.Sha256,
+			Size:           dist.Size,
+			CreatedAt:      dist.CreatedAt.Format(time.RFC3339),
+		}
+	}
+
+	return PythonDistributionListResponse{
+		Results: results,
+		Total:   countTotal,
+		Limit:   pageOpts.Limit,
+		Offset:  pageOpts.Offset,
+	}, nil
+}
+
+func assemblePythonPackageListFromRows(rows []pythonPackageVersionRow) []PythonPackageListItem {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	results := make([]PythonPackageListItem, 0)
+	var current PythonPackageListItem
+
+	for i, row := range rows {
+		if i == 0 || row.NameNormalized != current.NameNormalized {
+			if i > 0 {
+				results = append(results, current)
+			}
+			current = PythonPackageListItem{
+				Name:           row.Name,
+				NameNormalized: row.NameNormalized,
+				Versions:       []string{row.Version},
+				LatestVersions: []PythonVersionInfo{{
+					Version:   row.Version,
+					CreatedAt: row.CreatedAt.Format(time.RFC3339),
+				}},
+			}
+			continue
+		}
+
+		current.Versions = append(current.Versions, row.Version)
+		current.LatestVersions = append(current.LatestVersions, PythonVersionInfo{
+			Version:   row.Version,
+			CreatedAt: row.CreatedAt.Format(time.RFC3339),
+		})
+	}
+
+	return append(results, current)
+}
+
+// parsePythonRepositoryHref extracts the repository UUID from a Python repository href.
+// Example: /api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/
+func parsePythonRepositoryHref(href string) (string, error) {
+	parts := strings.Split(href, "/")
+	var nonEmptyParts []string
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+
+	if len(nonEmptyParts) < 8 {
+		return "", fmt.Errorf("invalid repository href format: %s", href)
+	}
+
+	return nonEmptyParts[len(nonEmptyParts)-1], nil
+}
+
+func getLatestPythonRepositoryVersion(ctx context.Context, conn *pgxpool.Conn, repoUUID string) (int, error) {
+	query := `
+		SELECT MAX(number)
+		FROM core_repositoryversion
+		WHERE repository_id = $1 AND complete = true
+	`
+
+	var latestVersion int
+	err := conn.QueryRow(ctx, query, repoUUID).Scan(&latestVersion)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get latest version for repository %s: %w", repoUUID, err)
+	}
+
+	return latestVersion, nil
+}

--- a/pkg/tangy/python_test.go
+++ b/pkg/tangy/python_test.go
@@ -1,0 +1,205 @@
+package tangy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePythonRepositoryHref(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		href    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid python repository href",
+			href: "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/",
+			want: "018c1c95-4281-76eb-b277-842cbad524f4",
+		},
+		{
+			name: "valid href without trailing slash",
+			href: "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4",
+			want: "018c1c95-4281-76eb-b277-842cbad524f4",
+		},
+		{
+			name:    "invalid href",
+			href:    "/api/pulp/default/api/v3/repositories/python/",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parsePythonRepositoryHref(tt.href)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAssemblePythonPackageListFromRows(t *testing.T) {
+	t.Parallel()
+
+	createdAt1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	createdAt2 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	createdAt3 := time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		rows []pythonPackageVersionRow
+		want []PythonPackageListItem
+	}{
+		{
+			name: "empty rows",
+			rows: nil,
+			want: nil,
+		},
+		{
+			name: "single package single version",
+			rows: []pythonPackageVersionRow{
+				{NameNormalized: "django", Name: "Django", Version: "5.0", CreatedAt: createdAt1},
+			},
+			want: []PythonPackageListItem{
+				{
+					Name:           "Django",
+					NameNormalized: "django",
+					Versions:       []string{"5.0"},
+					LatestVersions: []PythonVersionInfo{
+						{Version: "5.0", CreatedAt: createdAt1.Format(time.RFC3339)},
+					},
+				},
+			},
+		},
+		{
+			name: "single package multiple versions",
+			rows: []pythonPackageVersionRow{
+				{NameNormalized: "django", Name: "Django", Version: "4.2", CreatedAt: createdAt1},
+				{NameNormalized: "django", Name: "Django", Version: "5.0", CreatedAt: createdAt2},
+			},
+			want: []PythonPackageListItem{
+				{
+					Name:           "Django",
+					NameNormalized: "django",
+					Versions:       []string{"4.2", "5.0"},
+					LatestVersions: []PythonVersionInfo{
+						{Version: "4.2", CreatedAt: createdAt1.Format(time.RFC3339)},
+						{Version: "5.0", CreatedAt: createdAt2.Format(time.RFC3339)},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple packages",
+			rows: []pythonPackageVersionRow{
+				{NameNormalized: "django", Name: "Django", Version: "5.0", CreatedAt: createdAt1},
+				{NameNormalized: "requests", Name: "requests", Version: "2.31.0", CreatedAt: createdAt3},
+			},
+			want: []PythonPackageListItem{
+				{
+					Name:           "Django",
+					NameNormalized: "django",
+					Versions:       []string{"5.0"},
+					LatestVersions: []PythonVersionInfo{
+						{Version: "5.0", CreatedAt: createdAt1.Format(time.RFC3339)},
+					},
+				},
+				{
+					Name:           "requests",
+					NameNormalized: "requests",
+					Versions:       []string{"2.31.0"},
+					LatestVersions: []PythonVersionInfo{
+						{Version: "2.31.0", CreatedAt: createdAt3.Format(time.RFC3339)},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := assemblePythonPackageListFromRows(tt.rows)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMockTangyPythonPackageList(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	pageOpts := PageOptions{Offset: 0, Limit: 10}
+
+	expected := PythonPackageListResponse{
+		Results: []PythonPackageListItem{
+			{
+				Name:           "Django",
+				NameNormalized: "django",
+				Versions:       []string{"5.0"},
+				LatestVersions: []PythonVersionInfo{
+					{Version: "5.0", CreatedAt: "2024-01-01T12:00:00Z"},
+				},
+			},
+		},
+		Total:  1,
+		Limit:  10,
+		Offset: 0,
+	}
+
+	mockTangy.On("PythonPackageList", ctx, repoHref, pageOpts).Return(expected, nil)
+
+	got, err := mockTangy.PythonPackageList(ctx, repoHref, pageOpts)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestMockTangyPythonDistributionList(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	pageOpts := PageOptions{Offset: 0, Limit: 10}
+
+	expected := PythonDistributionListResponse{
+		Results: []PythonDistributionListItem{
+			{
+				Name:           "Django",
+				NameNormalized: "django",
+				Version:        "5.0",
+				Filename:       "django-5.0-py3-none-any.whl",
+				PackageType:    "bdist_wheel",
+				PythonVersion:  "py3",
+				Sha256:         "abc123",
+				Size:           1024,
+				CreatedAt:      "2024-01-01T12:00:00Z",
+			},
+		},
+		Total:  1,
+		Limit:  10,
+		Offset: 0,
+	}
+
+	mockTangy.On("PythonDistributionList", ctx, repoHref, "django", "5.0", pageOpts).Return(expected, nil)
+
+	got, err := mockTangy.PythonDistributionList(ctx, repoHref, "django", "5.0", pageOpts)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}

--- a/pkg/tangy/tangy_mock.go
+++ b/pkg/tangy/tangy_mock.go
@@ -70,6 +70,162 @@ func (_c *MockTangy_Close_Call) RunAndReturn(run func()) *MockTangy_Close_Call {
 	return _c
 }
 
+// PythonDistributionList provides a mock function for the type MockTangy
+func (_mock *MockTangy) PythonDistributionList(ctx context.Context, repositoryHref string, nameNormalized string, version string, pageOpts PageOptions) (PythonDistributionListResponse, error) {
+	ret := _mock.Called(ctx, repositoryHref, nameNormalized, version, pageOpts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PythonDistributionList")
+	}
+
+	var r0 PythonDistributionListResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, PageOptions) (PythonDistributionListResponse, error)); ok {
+		return returnFunc(ctx, repositoryHref, nameNormalized, version, pageOpts)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, PageOptions) PythonDistributionListResponse); ok {
+		r0 = returnFunc(ctx, repositoryHref, nameNormalized, version, pageOpts)
+	} else {
+		r0 = ret.Get(0).(PythonDistributionListResponse)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, PageOptions) error); ok {
+		r1 = returnFunc(ctx, repositoryHref, nameNormalized, version, pageOpts)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTangy_PythonDistributionList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PythonDistributionList'
+type MockTangy_PythonDistributionList_Call struct {
+	*mock.Call
+}
+
+// PythonDistributionList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repositoryHref string
+//   - nameNormalized string
+//   - version string
+//   - pageOpts PageOptions
+func (_e *MockTangy_Expecter) PythonDistributionList(ctx any, repositoryHref any, nameNormalized any, version any, pageOpts any) *MockTangy_PythonDistributionList_Call {
+	return &MockTangy_PythonDistributionList_Call{Call: _e.mock.On("PythonDistributionList", ctx, repositoryHref, nameNormalized, version, pageOpts)}
+}
+
+func (_c *MockTangy_PythonDistributionList_Call) Run(run func(ctx context.Context, repositoryHref string, nameNormalized string, version string, pageOpts PageOptions)) *MockTangy_PythonDistributionList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 PageOptions
+		if args[4] != nil {
+			arg4 = args[4].(PageOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTangy_PythonDistributionList_Call) Return(pythonDistributionListResponse PythonDistributionListResponse, err error) *MockTangy_PythonDistributionList_Call {
+	_c.Call.Return(pythonDistributionListResponse, err)
+	return _c
+}
+
+func (_c *MockTangy_PythonDistributionList_Call) RunAndReturn(run func(ctx context.Context, repositoryHref string, nameNormalized string, version string, pageOpts PageOptions) (PythonDistributionListResponse, error)) *MockTangy_PythonDistributionList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PythonPackageList provides a mock function for the type MockTangy
+func (_mock *MockTangy) PythonPackageList(ctx context.Context, repositoryHref string, pageOpts PageOptions) (PythonPackageListResponse, error) {
+	ret := _mock.Called(ctx, repositoryHref, pageOpts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PythonPackageList")
+	}
+
+	var r0 PythonPackageListResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, PageOptions) (PythonPackageListResponse, error)); ok {
+		return returnFunc(ctx, repositoryHref, pageOpts)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, PageOptions) PythonPackageListResponse); ok {
+		r0 = returnFunc(ctx, repositoryHref, pageOpts)
+	} else {
+		r0 = ret.Get(0).(PythonPackageListResponse)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, PageOptions) error); ok {
+		r1 = returnFunc(ctx, repositoryHref, pageOpts)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTangy_PythonPackageList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PythonPackageList'
+type MockTangy_PythonPackageList_Call struct {
+	*mock.Call
+}
+
+// PythonPackageList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repositoryHref string
+//   - pageOpts PageOptions
+func (_e *MockTangy_Expecter) PythonPackageList(ctx any, repositoryHref any, pageOpts any) *MockTangy_PythonPackageList_Call {
+	return &MockTangy_PythonPackageList_Call{Call: _e.mock.On("PythonPackageList", ctx, repositoryHref, pageOpts)}
+}
+
+func (_c *MockTangy_PythonPackageList_Call) Run(run func(ctx context.Context, repositoryHref string, pageOpts PageOptions)) *MockTangy_PythonPackageList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 PageOptions
+		if args[2] != nil {
+			arg2 = args[2].(PageOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTangy_PythonPackageList_Call) Return(pythonPackageListResponse PythonPackageListResponse, err error) *MockTangy_PythonPackageList_Call {
+	_c.Call.Return(pythonPackageListResponse, err)
+	return _c
+}
+
+func (_c *MockTangy_PythonPackageList_Call) RunAndReturn(run func(ctx context.Context, repositoryHref string, pageOpts PageOptions) (PythonPackageListResponse, error)) *MockTangy_PythonPackageList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RpmRepositoryVersionEnvironmentSearch provides a mock function for the type MockTangy
 func (_mock *MockTangy) RpmRepositoryVersionEnvironmentSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmEnvironmentSearch, error) {
 	ret := _mock.Called(ctx, hrefs, search, limit)
@@ -108,7 +264,7 @@ type MockTangy_RpmRepositoryVersionEnvironmentSearch_Call struct {
 //   - hrefs []string
 //   - search string
 //   - limit int
-func (_e *MockTangy_Expecter) RpmRepositoryVersionEnvironmentSearch(ctx interface{}, hrefs interface{}, search interface{}, limit interface{}) *MockTangy_RpmRepositoryVersionEnvironmentSearch_Call {
+func (_e *MockTangy_Expecter) RpmRepositoryVersionEnvironmentSearch(ctx any, hrefs any, search any, limit any) *MockTangy_RpmRepositoryVersionEnvironmentSearch_Call {
 	return &MockTangy_RpmRepositoryVersionEnvironmentSearch_Call{Call: _e.mock.On("RpmRepositoryVersionEnvironmentSearch", ctx, hrefs, search, limit)}
 }
 
@@ -194,7 +350,7 @@ type MockTangy_RpmRepositoryVersionErrataList_Call struct {
 //   - hrefs []string
 //   - filterOpts ErrataListFilters
 //   - pageOpts PageOptions
-func (_e *MockTangy_Expecter) RpmRepositoryVersionErrataList(ctx interface{}, hrefs interface{}, filterOpts interface{}, pageOpts interface{}) *MockTangy_RpmRepositoryVersionErrataList_Call {
+func (_e *MockTangy_Expecter) RpmRepositoryVersionErrataList(ctx any, hrefs any, filterOpts any, pageOpts any) *MockTangy_RpmRepositoryVersionErrataList_Call {
 	return &MockTangy_RpmRepositoryVersionErrataList_Call{Call: _e.mock.On("RpmRepositoryVersionErrataList", ctx, hrefs, filterOpts, pageOpts)}
 }
 
@@ -274,7 +430,7 @@ type MockTangy_RpmRepositoryVersionModuleStreamsList_Call struct {
 //   - hrefs []string
 //   - filterOpts ModuleStreamListFilters
 //   - sortBy string
-func (_e *MockTangy_Expecter) RpmRepositoryVersionModuleStreamsList(ctx interface{}, hrefs interface{}, filterOpts interface{}, sortBy interface{}) *MockTangy_RpmRepositoryVersionModuleStreamsList_Call {
+func (_e *MockTangy_Expecter) RpmRepositoryVersionModuleStreamsList(ctx any, hrefs any, filterOpts any, sortBy any) *MockTangy_RpmRepositoryVersionModuleStreamsList_Call {
 	return &MockTangy_RpmRepositoryVersionModuleStreamsList_Call{Call: _e.mock.On("RpmRepositoryVersionModuleStreamsList", ctx, hrefs, filterOpts, sortBy)}
 }
 
@@ -354,7 +510,7 @@ type MockTangy_RpmRepositoryVersionPackageGroupSearch_Call struct {
 //   - hrefs []string
 //   - search string
 //   - limit int
-func (_e *MockTangy_Expecter) RpmRepositoryVersionPackageGroupSearch(ctx interface{}, hrefs interface{}, search interface{}, limit interface{}) *MockTangy_RpmRepositoryVersionPackageGroupSearch_Call {
+func (_e *MockTangy_Expecter) RpmRepositoryVersionPackageGroupSearch(ctx any, hrefs any, search any, limit any) *MockTangy_RpmRepositoryVersionPackageGroupSearch_Call {
 	return &MockTangy_RpmRepositoryVersionPackageGroupSearch_Call{Call: _e.mock.On("RpmRepositoryVersionPackageGroupSearch", ctx, hrefs, search, limit)}
 }
 
@@ -440,7 +596,7 @@ type MockTangy_RpmRepositoryVersionPackageList_Call struct {
 //   - hrefs []string
 //   - filterOpts RpmListFilters
 //   - pageOpts PageOptions
-func (_e *MockTangy_Expecter) RpmRepositoryVersionPackageList(ctx interface{}, hrefs interface{}, filterOpts interface{}, pageOpts interface{}) *MockTangy_RpmRepositoryVersionPackageList_Call {
+func (_e *MockTangy_Expecter) RpmRepositoryVersionPackageList(ctx any, hrefs any, filterOpts any, pageOpts any) *MockTangy_RpmRepositoryVersionPackageList_Call {
 	return &MockTangy_RpmRepositoryVersionPackageList_Call{Call: _e.mock.On("RpmRepositoryVersionPackageList", ctx, hrefs, filterOpts, pageOpts)}
 }
 
@@ -520,7 +676,7 @@ type MockTangy_RpmRepositoryVersionPackageSearch_Call struct {
 //   - hrefs []string
 //   - search string
 //   - limit int
-func (_e *MockTangy_Expecter) RpmRepositoryVersionPackageSearch(ctx interface{}, hrefs interface{}, search interface{}, limit interface{}) *MockTangy_RpmRepositoryVersionPackageSearch_Call {
+func (_e *MockTangy_Expecter) RpmRepositoryVersionPackageSearch(ctx any, hrefs any, search any, limit any) *MockTangy_RpmRepositoryVersionPackageSearch_Call {
 	return &MockTangy_RpmRepositoryVersionPackageSearch_Call{Call: _e.mock.On("RpmRepositoryVersionPackageSearch", ctx, hrefs, search, limit)}
 }
 


### PR DESCRIPTION
This PR:

- Adds `PythonPackageList` to list packages from a repo's latest version, grouped by `name_normalized`
- Adds `PythonDistributionList` to list distribution files for a given `name_normalized` and version
- Queries `python_pythonpackagecontent` with SQL pagination and `latest_versions` per package version
- Adds `internal/zestwrapper/python.go` to sync `shelf-reader` from PyPI for integration tests
- Adds unit tests for href parsing, response assembly, and `MockTangy` usage
- Adds integration tests (`TestPythonSuite`) against a local Pulp instance with the Python plugin
- Updates README with Python usage examples and instructions for running unit and integration tests
- Regenerates `tangy_mock.go` for the new `Tangy` interface methods