### PR TITLE
fix: use prefix search for package list filters

### DIFF
--- a/pkg/tangy/maven.go
+++ b/pkg/tangy/maven.go
@@ -99,8 +99,8 @@ func (t *tangyImpl) MavenPackageList(ctx context.Context, repositoryHref string,
 	searchFilter := ""
 	if filterOpts.Search != "" {
 		args["searchFilter"] = filterOpts.Search
-		searchFilter = ` AND (rp.group_id ILIKE CONCAT('%', @searchFilter::text, '%')
-			OR rp.artifact_id ILIKE CONCAT('%', @searchFilter::text, '%'))`
+		searchFilter = ` AND (rp.group_id ILIKE CONCAT(@searchFilter::text, '%')
+			OR rp.artifact_id ILIKE CONCAT(@searchFilter::text, '%'))`
 	}
 	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
 	if err != nil {

--- a/pkg/tangy/python.go
+++ b/pkg/tangy/python.go
@@ -110,8 +110,8 @@ func (t *tangyImpl) PythonPackageList(ctx context.Context, repositoryHref string
 	searchFilter := ""
 	if filterOpts.Search != "" {
 		args["searchFilter"] = filterOpts.Search
-		searchFilter = ` AND (rp.name ILIKE CONCAT('%', @searchFilter::text, '%')
-			OR rp.name_normalized ILIKE CONCAT('%', @searchFilter::text, '%'))`
+		searchFilter = ` AND (rp.name ILIKE CONCAT(@searchFilter::text, '%')
+			OR rp.name_normalized ILIKE CONCAT(@searchFilter::text, '%'))`
 	}
 	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
 	if err != nil {


### PR DESCRIPTION
Package list filters originally used substring matches (anywhere in the string), this improves that to match from the beginning instead. Thanks Ryan for the suggestion :) 