### PR TITLE
HMS-10963: add python package details method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ if err != nil {
   return err
 }
 
+// Use Tangy to get metadata for a specific Python package version (filter by name_normalized)
+detail, err := t.PythonPackageGet(context.Background(), repositoryHref, "shelf-reader", "0.1")
+if err != nil {
+  return err
+}
+
 // Use Tangy to list all builds (artifacts) for a specific Maven package version
 buildResponse, err := t.MavenBuildList(context.Background(), repositoryHref, "org.xutils", "xutils", "3.8.5", tangy.PageOptions{Offset: 0, Limit: 10})
 if err != nil {
@@ -85,6 +91,7 @@ Python support queries the `python_pythonpackagecontent` table. Each row is one 
 
 - **`PythonPackageList`** — lists packages in the latest repository version, grouped by `name_normalized`, with all versions and `latest_versions` (most recent `pulp_created` per version). Supports optional `Search` filter on `name` or `name_normalized`. Pagination is done in SQL.
 - **`PythonDistributionList`** — lists distribution files for a given `name_normalized` and `version`. Pagination is done in SQL.
+- **`PythonPackageGet`** — returns package metadata for a given `name_normalized` and `version`, plus all other versions available in the repository and all distribution files for that version. Metadata is taken from one representative distribution (sdist preferred). Returns `ErrPythonPackageNotFound` when the package version is not in the repository.
 
 Repository href format:
 

--- a/internal/test/integration/python_test.go
+++ b/internal/test/integration/python_test.go
@@ -173,6 +173,59 @@ func (p *PythonSuite) TestPythonDistributionList() {
 	assert.NotEmpty(p.T(), packageTypes)
 }
 
+func (p *PythonSuite) TestPythonPackageGet() {
+	detail, err := p.tangy.PythonPackageGet(
+		context.Background(),
+		p.repositoryHref,
+		"shelf-reader",
+		"0.1",
+	)
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), "shelf-reader", detail.NameNormalized)
+	assert.Equal(p.T(), "0.1", detail.Version)
+	assert.NotEmpty(p.T(), detail.Name)
+	assert.NotEmpty(p.T(), detail.LastUpdated)
+	assert.Contains(p.T(), detail.Versions, "0.1")
+	require.NotEmpty(p.T(), detail.LatestVersions)
+
+	foundVersion := false
+	for _, latest := range detail.LatestVersions {
+		if latest.Version == "0.1" {
+			foundVersion = true
+			assert.NotEmpty(p.T(), latest.CreatedAt)
+		}
+	}
+	assert.True(p.T(), foundVersion)
+
+	require.NotEmpty(p.T(), detail.Distributions)
+	for _, dist := range detail.Distributions {
+		assert.Equal(p.T(), "shelf-reader", dist.NameNormalized)
+		assert.Equal(p.T(), "0.1", dist.Version)
+		assert.NotEmpty(p.T(), dist.Filename)
+		assert.NotEmpty(p.T(), dist.PackageType)
+		assert.NotEmpty(p.T(), dist.Sha256)
+		assert.NotZero(p.T(), dist.Size)
+		assert.NotEmpty(p.T(), dist.CreatedAt)
+	}
+}
+
+func (p *PythonSuite) TestPythonPackageGetNotFound() {
+	_, err := p.tangy.PythonPackageGet(
+		context.Background(),
+		p.repositoryHref,
+		"shelf-reader",
+		"9.9.9",
+	)
+	require.Error(p.T(), err)
+	assert.ErrorIs(p.T(), err, tangy.ErrPythonPackageNotFound)
+}
+
+func (p *PythonSuite) TestPythonPackageGetEmptyHref() {
+	detail, err := p.tangy.PythonPackageGet(context.Background(), "", "shelf-reader", "0.1")
+	require.NoError(p.T(), err)
+	assert.Empty(p.T(), detail.NameNormalized)
+}
+
 func (p *PythonSuite) TestPythonDistributionListPagination() {
 	response, err := p.tangy.PythonDistributionList(
 		context.Background(),

--- a/pkg/tangy/interface.go
+++ b/pkg/tangy/interface.go
@@ -67,6 +67,7 @@ type Tangy interface {
 	RpmRepositoryVersionErrataList(ctx context.Context, hrefs []string, filterOpts ErrataListFilters, pageOpts PageOptions) ([]ErrataListItem, int, error)
 	PythonPackageList(ctx context.Context, repositoryHref string, filterOpts PythonPackageListFilters, pageOpts PageOptions) (PythonPackageListResponse, error)
 	PythonDistributionList(ctx context.Context, repositoryHref, nameNormalized, version string, pageOpts PageOptions) (PythonDistributionListResponse, error)
+	PythonPackageGet(ctx context.Context, repositoryHref, nameNormalized, version string) (PythonPackageDetail, error)
 	MavenPackageList(ctx context.Context, repositoryHref string, filterOpts MavenPackageListFilters, pageOpts PageOptions) (MavenPackageListResponse, error)
 	MavenBuildList(ctx context.Context, repositoryHref, groupID, artifactID, version string, pageOpts PageOptions) (MavenBuildListResponse, error)
 	Close()

--- a/pkg/tangy/python.go
+++ b/pkg/tangy/python.go
@@ -2,6 +2,8 @@ package tangy
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -52,6 +54,36 @@ type PythonDistributionListResponse struct {
 	Offset  int                          `json:"offset"`
 }
 
+// PythonPackageDetail holds metadata for a specific package name and version in a repository.
+// Metadata is taken from one representative distribution (sdist preferred, then most recently synced).
+type PythonPackageDetail struct {
+	Name                   string              `json:"name"`
+	NameNormalized         string              `json:"name_normalized"`
+	Version                string              `json:"version"`
+	Summary                string              `json:"summary"`
+	Description            string              `json:"description"`
+	DescriptionContentType string              `json:"description_content_type,omitempty"`
+	Author                 string              `json:"author"`
+	AuthorEmail            string              `json:"author_email,omitempty"`
+	Maintainer             string              `json:"maintainer,omitempty"`
+	MaintainerEmail        string              `json:"maintainer_email,omitempty"`
+	License                string              `json:"license"`
+	LicenseExpression      string              `json:"license_expression,omitempty"`
+	HomePage               string              `json:"home_page,omitempty"`
+	ProjectURL             string              `json:"project_url"`
+	ProjectURLs            map[string]string   `json:"project_urls,omitempty"`
+	Keywords               string              `json:"keywords,omitempty"`
+	RequiresPython         string              `json:"requires_python,omitempty"`
+	Classifiers            []string            `json:"classifiers,omitempty"`
+	RequiresDist           []string            `json:"requires_dist,omitempty"`
+	LastUpdated            string                      `json:"last_updated"`
+	Versions               []string                    `json:"versions"`
+	LatestVersions         []PythonVersionInfo         `json:"latest_versions"`
+	Distributions          []PythonDistributionListItem `json:"distributions"`
+}
+
+var ErrPythonPackageNotFound = errors.New("python package not found")
+
 type pythonPackageVersionRow struct {
 	NameNormalized string
 	Name           string
@@ -69,6 +101,31 @@ type pythonDistributionRow struct {
 	Sha256         string
 	Size           int64
 	CreatedAt      time.Time
+}
+
+type pythonPackageDetailRow struct {
+	Name                   string
+	NameNormalized         string
+	Version                string
+	Summary                string
+	Description            string
+	DescriptionContentType string
+	Author                 string
+	AuthorEmail            string
+	Maintainer             string
+	MaintainerEmail        string
+	License                string
+	LicenseExpression      string
+	HomePage               string
+	ProjectURL             string
+	ProjectURLs            []byte
+	Keywords               string
+	RequiresPython         string
+	Classifiers            []byte
+	RequiresDist           []byte
+	LastUpdated            time.Time
+	Versions               []string
+	LatestVersionsJSON     []byte
 }
 
 // PythonPackageList lists Python packages from the latest version of a repository,
@@ -227,6 +284,156 @@ func (t *tangyImpl) PythonDistributionList(ctx context.Context, repositoryHref, 
 		return PythonDistributionListResponse{}, err
 	}
 
+	distributions, err := fetchPythonDistributionRows(ctx, conn, innerUnion, args, pageOpts.Limit, pageOpts.Offset)
+	if err != nil {
+		return PythonDistributionListResponse{}, err
+	}
+
+	return PythonDistributionListResponse{
+		Results: pythonDistributionRowsToItems(distributions),
+		Total:   countTotal,
+		Limit:   pageOpts.Limit,
+		Offset:  pageOpts.Offset,
+	}, nil
+}
+
+// PythonPackageGet returns metadata for a specific package name_normalized and version
+// from the latest version of a repository, plus all other versions available in that repository.
+func (t *tangyImpl) PythonPackageGet(ctx context.Context, repositoryHref, nameNormalized, version string) (PythonPackageDetail, error) {
+	if repositoryHref == "" {
+		return PythonPackageDetail{}, nil
+	}
+
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return PythonPackageDetail{}, err
+	}
+	defer conn.Release()
+
+	repoUUID, err := parsePythonRepositoryHref(repositoryHref)
+	if err != nil {
+		return PythonPackageDetail{}, fmt.Errorf("error parsing repository href: %w", err)
+	}
+
+	latestVersion, err := getLatestPythonRepositoryVersion(ctx, conn, repoUUID)
+	if err != nil {
+		return PythonPackageDetail{}, fmt.Errorf("error getting latest repository version: %w", err)
+	}
+
+	repoVerMap := []ParsedRepoVersion{{
+		RepositoryUUID: repoUUID,
+		Version:        latestVersion,
+	}}
+
+	args := pgx.NamedArgs{
+		"name_normalized": nameNormalized,
+		"version":         version,
+	}
+	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
+	if err != nil {
+		return PythonPackageDetail{}, err
+	}
+
+	query := `
+		WITH filtered AS (
+			SELECT rp.name, rp.name_normalized, rp.version, rp.summary, rp.description,
+			       rp.description_content_type, rp.author, rp.author_email,
+			       rp.maintainer, rp.maintainer_email, rp.license, rp.license_expression,
+			       rp.home_page, rp.project_url, rp.project_urls, rp.keywords,
+			       rp.requires_python, rp.classifiers, rp.requires_dist,
+			       rp.packagetype, cc.pulp_created
+			FROM python_pythonpackagecontent rp
+			INNER JOIN core_content cc ON rp.content_ptr_id = cc.pulp_id
+	` + innerUnion + `
+			AND rp.name_normalized = @name_normalized
+		),
+		version_agg AS (
+			SELECT
+				ARRAY_AGG(version ORDER BY version) AS versions,
+				COALESCE(
+					JSON_AGG(
+						JSON_BUILD_OBJECT('version', version, 'created_at', last_updated)
+						ORDER BY version
+					),
+					'[]'::json
+				) AS latest_versions_json
+			FROM (
+				SELECT version, MAX(pulp_created) AS last_updated
+				FROM filtered
+				GROUP BY version
+			) v
+		),
+		detail AS (
+			SELECT f.*,
+			       MAX(f.pulp_created) OVER () AS last_updated,
+			       ROW_NUMBER() OVER (
+			           ORDER BY CASE WHEN f.packagetype = 'sdist' THEN 0 ELSE 1 END,
+			                    f.pulp_created DESC
+			       ) AS rn
+			FROM filtered f
+			WHERE f.version = @version
+		)
+		SELECT d.name, d.name_normalized, d.version, d.summary, d.description,
+		       d.description_content_type, d.author, d.author_email,
+		       d.maintainer, d.maintainer_email, d.license, d.license_expression,
+		       d.home_page, d.project_url, d.project_urls, d.keywords,
+		       d.requires_python, d.classifiers, d.requires_dist,
+		       d.last_updated, va.versions, va.latest_versions_json
+		FROM detail d
+		CROSS JOIN version_agg va
+		WHERE d.rn = 1`
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return PythonPackageDetail{}, err
+	}
+
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[pythonPackageDetailRow])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return PythonPackageDetail{}, fmt.Errorf("%w: %s@%s", ErrPythonPackageNotFound, nameNormalized, version)
+		}
+		return PythonPackageDetail{}, err
+	}
+
+	latestVersions, err := parsePythonLatestVersionsJSON(row.LatestVersionsJSON)
+	if err != nil {
+		return PythonPackageDetail{}, err
+	}
+
+	distributions, err := fetchPythonDistributionRows(ctx, conn, innerUnion, args, 0, 0)
+	if err != nil {
+		return PythonPackageDetail{}, err
+	}
+
+	return PythonPackageDetail{
+		Name:                   row.Name,
+		NameNormalized:         row.NameNormalized,
+		Version:                row.Version,
+		Summary:                row.Summary,
+		Description:            row.Description,
+		DescriptionContentType: row.DescriptionContentType,
+		Author:                 row.Author,
+		AuthorEmail:            row.AuthorEmail,
+		Maintainer:             row.Maintainer,
+		MaintainerEmail:        row.MaintainerEmail,
+		License:                row.License,
+		LicenseExpression:      row.LicenseExpression,
+		HomePage:               row.HomePage,
+		ProjectURL:             row.ProjectURL,
+		ProjectURLs:            parsePythonJSONStringMap(row.ProjectURLs),
+		Keywords:               row.Keywords,
+		RequiresPython:         row.RequiresPython,
+		Classifiers:            parsePythonJSONStringSlice(row.Classifiers),
+		RequiresDist:           parsePythonJSONStringSlice(row.RequiresDist),
+		LastUpdated:            row.LastUpdated.Format(time.RFC3339),
+		Versions:               row.Versions,
+		LatestVersions:         latestVersions,
+		Distributions:          pythonDistributionRowsToItems(distributions),
+	}, nil
+}
+
+func fetchPythonDistributionRows(ctx context.Context, conn *pgxpool.Conn, innerUnion string, args pgx.NamedArgs, limit, offset int) ([]pythonDistributionRow, error) {
 	query := `
 		SELECT rp.name, rp.name_normalized, rp.version, rp.filename, rp.packagetype,
 		       rp.python_version, rp.sha256, rp.size, cc.pulp_created AS created_at
@@ -235,19 +442,24 @@ func (t *tangyImpl) PythonDistributionList(ctx context.Context, repositoryHref, 
 	` + innerUnion + `
 		AND rp.name_normalized = @name_normalized
 		AND rp.version = @version
-		ORDER BY cc.pulp_created DESC
+		ORDER BY cc.pulp_created DESC`
+
+	if limit > 0 {
+		args["limit"] = limit
+		args["offset"] = offset
+		query += `
 		LIMIT @limit OFFSET @offset`
+	}
 
 	rows, err := conn.Query(ctx, query, args)
 	if err != nil {
-		return PythonDistributionListResponse{}, err
+		return nil, err
 	}
 
-	distributions, err := pgx.CollectRows(rows, pgx.RowToStructByName[pythonDistributionRow])
-	if err != nil {
-		return PythonDistributionListResponse{}, err
-	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[pythonDistributionRow])
+}
 
+func pythonDistributionRowsToItems(distributions []pythonDistributionRow) []PythonDistributionListItem {
 	results := make([]PythonDistributionListItem, len(distributions))
 	for i, dist := range distributions {
 		results[i] = PythonDistributionListItem{
@@ -262,13 +474,54 @@ func (t *tangyImpl) PythonDistributionList(ctx context.Context, repositoryHref, 
 			CreatedAt:      dist.CreatedAt.Format(time.RFC3339),
 		}
 	}
+	return results
+}
 
-	return PythonDistributionListResponse{
-		Results: results,
-		Total:   countTotal,
-		Limit:   pageOpts.Limit,
-		Offset:  pageOpts.Offset,
-	}, nil
+func parsePythonLatestVersionsJSON(data []byte) ([]PythonVersionInfo, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var raw []struct {
+		Version   string    `json:"version"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse latest_versions: %w", err)
+	}
+
+	latestVersions := make([]PythonVersionInfo, len(raw))
+	for i, item := range raw {
+		latestVersions[i] = PythonVersionInfo{
+			Version:   item.Version,
+			CreatedAt: item.CreatedAt.Format(time.RFC3339),
+		}
+	}
+	return latestVersions, nil
+}
+
+func parsePythonJSONStringSlice(data []byte) []string {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+
+	var values []string
+	if err := json.Unmarshal(data, &values); err != nil {
+		return nil
+	}
+	return values
+}
+
+func parsePythonJSONStringMap(data []byte) map[string]string {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+
+	var values map[string]string
+	if err := json.Unmarshal(data, &values); err != nil {
+		return nil
+	}
+	return values
 }
 
 func assemblePythonPackageListFromRows(rows []pythonPackageVersionRow) []PythonPackageListItem {

--- a/pkg/tangy/python.go
+++ b/pkg/tangy/python.go
@@ -57,28 +57,28 @@ type PythonDistributionListResponse struct {
 // PythonPackageDetail holds metadata for a specific package name and version in a repository.
 // Metadata is taken from one representative distribution (sdist preferred, then most recently synced).
 type PythonPackageDetail struct {
-	Name                   string              `json:"name"`
-	NameNormalized         string              `json:"name_normalized"`
-	Version                string              `json:"version"`
-	Summary                string              `json:"summary"`
-	Description            string              `json:"description"`
-	DescriptionContentType string              `json:"description_content_type,omitempty"`
-	Author                 string              `json:"author"`
-	AuthorEmail            string              `json:"author_email,omitempty"`
-	Maintainer             string              `json:"maintainer,omitempty"`
-	MaintainerEmail        string              `json:"maintainer_email,omitempty"`
-	License                string              `json:"license"`
-	LicenseExpression      string              `json:"license_expression,omitempty"`
-	HomePage               string              `json:"home_page,omitempty"`
-	ProjectURL             string              `json:"project_url"`
-	ProjectURLs            map[string]string   `json:"project_urls,omitempty"`
-	Keywords               string              `json:"keywords,omitempty"`
-	RequiresPython         string              `json:"requires_python,omitempty"`
-	Classifiers            []string            `json:"classifiers,omitempty"`
-	RequiresDist           []string            `json:"requires_dist,omitempty"`
-	LastUpdated            string                      `json:"last_updated"`
-	Versions               []string                    `json:"versions"`
-	LatestVersions         []PythonVersionInfo         `json:"latest_versions"`
+	Name                   string                       `json:"name"`
+	NameNormalized         string                       `json:"name_normalized"`
+	Version                string                       `json:"version"`
+	Summary                string                       `json:"summary"`
+	Description            string                       `json:"description"`
+	DescriptionContentType string                       `json:"description_content_type,omitempty"`
+	Author                 string                       `json:"author"`
+	AuthorEmail            string                       `json:"author_email,omitempty"`
+	Maintainer             string                       `json:"maintainer,omitempty"`
+	MaintainerEmail        string                       `json:"maintainer_email,omitempty"`
+	License                string                       `json:"license"`
+	LicenseExpression      string                       `json:"license_expression,omitempty"`
+	HomePage               string                       `json:"home_page,omitempty"`
+	ProjectURL             string                       `json:"project_url"`
+	ProjectURLs            map[string]string            `json:"project_urls,omitempty"`
+	Keywords               string                       `json:"keywords,omitempty"`
+	RequiresPython         string                       `json:"requires_python,omitempty"`
+	Classifiers            []string                     `json:"classifiers,omitempty"`
+	RequiresDist           []string                     `json:"requires_dist,omitempty"`
+	LastUpdated            string                       `json:"last_updated"`
+	Versions               []string                     `json:"versions"`
+	LatestVersions         []PythonVersionInfo          `json:"latest_versions"`
 	Distributions          []PythonDistributionListItem `json:"distributions"`
 }
 

--- a/pkg/tangy/python_test.go
+++ b/pkg/tangy/python_test.go
@@ -204,3 +204,84 @@ func TestMockTangyPythonDistributionList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expected, got)
 }
+
+func TestMockTangyPythonPackageGet(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+
+	expected := PythonPackageDetail{
+		Name:           "Django",
+		NameNormalized: "django",
+		Version:        "5.0",
+		Summary:        "A high-level Python web framework",
+		Description:    "Django is a high-level Python web framework.",
+		Author:         "Django Software Foundation",
+		License:        "BSD-3-Clause",
+		ProjectURL:     "https://www.djangoproject.com/",
+		LastUpdated:    "2024-01-01T12:00:00Z",
+		Versions:       []string{"4.2", "5.0"},
+		LatestVersions: []PythonVersionInfo{
+			{Version: "4.2", CreatedAt: "2023-01-01T12:00:00Z"},
+			{Version: "5.0", CreatedAt: "2024-01-01T12:00:00Z"},
+		},
+		Distributions: []PythonDistributionListItem{
+			{
+				Name:           "Django",
+				NameNormalized: "django",
+				Version:        "5.0",
+				Filename:       "django-5.0-py3-none-any.whl",
+				PackageType:    "bdist_wheel",
+				PythonVersion:  "py3",
+				Sha256:         "abc123",
+				Size:           1024,
+				CreatedAt:      "2024-01-01T12:00:00Z",
+			},
+		},
+	}
+
+	mockTangy.On("PythonPackageGet", ctx, repoHref, "django", "5.0").Return(expected, nil)
+
+	got, err := mockTangy.PythonPackageGet(ctx, repoHref, "django", "5.0")
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestParsePythonJSONStringSlice(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, parsePythonJSONStringSlice(nil))
+	assert.Nil(t, parsePythonJSONStringSlice([]byte("null")))
+
+	got := parsePythonJSONStringSlice([]byte(`["requests", "urllib3"]`))
+	assert.Equal(t, []string{"requests", "urllib3"}, got)
+}
+
+func TestParsePythonJSONStringMap(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, parsePythonJSONStringMap(nil))
+	assert.Nil(t, parsePythonJSONStringMap([]byte("null")))
+
+	got := parsePythonJSONStringMap([]byte(`{"Homepage": "https://example.com", "Source": "https://github.com/example"}`))
+	assert.Equal(t, map[string]string{
+		"Homepage": "https://example.com",
+		"Source":   "https://github.com/example",
+	}, got)
+}
+
+func TestParsePythonLatestVersionsJSON(t *testing.T) {
+	t.Parallel()
+
+	got, err := parsePythonLatestVersionsJSON([]byte(`[
+		{"version": "1.0", "created_at": "2024-01-01T12:00:00Z"},
+		{"version": "2.0", "created_at": "2024-06-01T12:00:00Z"}
+	]`))
+	require.NoError(t, err)
+	assert.Equal(t, []PythonVersionInfo{
+		{Version: "1.0", CreatedAt: "2024-01-01T12:00:00Z"},
+		{Version: "2.0", CreatedAt: "2024-06-01T12:00:00Z"},
+	}, got)
+}

--- a/pkg/tangy/tangy_mock.go
+++ b/pkg/tangy/tangy_mock.go
@@ -322,6 +322,84 @@ func (_c *MockTangy_PythonDistributionList_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// PythonPackageGet provides a mock function for the type MockTangy
+func (_mock *MockTangy) PythonPackageGet(ctx context.Context, repositoryHref string, nameNormalized string, version string) (PythonPackageDetail, error) {
+	ret := _mock.Called(ctx, repositoryHref, nameNormalized, version)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PythonPackageGet")
+	}
+
+	var r0 PythonPackageDetail
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (PythonPackageDetail, error)); ok {
+		return returnFunc(ctx, repositoryHref, nameNormalized, version)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) PythonPackageDetail); ok {
+		r0 = returnFunc(ctx, repositoryHref, nameNormalized, version)
+	} else {
+		r0 = ret.Get(0).(PythonPackageDetail)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = returnFunc(ctx, repositoryHref, nameNormalized, version)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTangy_PythonPackageGet_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PythonPackageGet'
+type MockTangy_PythonPackageGet_Call struct {
+	*mock.Call
+}
+
+// PythonPackageGet is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repositoryHref string
+//   - nameNormalized string
+//   - version string
+func (_e *MockTangy_Expecter) PythonPackageGet(ctx any, repositoryHref any, nameNormalized any, version any) *MockTangy_PythonPackageGet_Call {
+	return &MockTangy_PythonPackageGet_Call{Call: _e.mock.On("PythonPackageGet", ctx, repositoryHref, nameNormalized, version)}
+}
+
+func (_c *MockTangy_PythonPackageGet_Call) Run(run func(ctx context.Context, repositoryHref string, nameNormalized string, version string)) *MockTangy_PythonPackageGet_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTangy_PythonPackageGet_Call) Return(pythonPackageDetail PythonPackageDetail, err error) *MockTangy_PythonPackageGet_Call {
+	_c.Call.Return(pythonPackageDetail, err)
+	return _c
+}
+
+func (_c *MockTangy_PythonPackageGet_Call) RunAndReturn(run func(ctx context.Context, repositoryHref string, nameNormalized string, version string) (PythonPackageDetail, error)) *MockTangy_PythonPackageGet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PythonPackageList provides a mock function for the type MockTangy
 func (_mock *MockTangy) PythonPackageList(ctx context.Context, repositoryHref string, filterOpts PythonPackageListFilters, pageOpts PageOptions) (PythonPackageListResponse, error) {
 	ret := _mock.Called(ctx, repositoryHref, filterOpts, pageOpts)


### PR DESCRIPTION
This PR:
- Adds `PythonPackageGet` to fetch package metadata by `name_normalized` and version
- Returns repo versions, distribution files, and metadata from a representative sdist row
- Extracts shared distribution query helper used by `PythonDistributionList` and package get
- Adds unit/integration tests, mock updates, and README docs for the new API