### PR TITLE
HMS-10965: add method to get details of all versions for a package + refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Python support queries the `python_pythonpackagecontent` table. Each row is one 
 - **`PythonPackageList`** — lists packages in the latest repository version, grouped by `name_normalized`, with all versions and `latest_versions` (most recent `pulp_created` per version). Supports optional `Search` filter on `name` or `name_normalized`. Pagination is done in SQL.
 - **`PythonDistributionList`** — lists distribution files for a given `name_normalized` and `version`. Pagination is done in SQL.
 - **`PythonPackageGet`** — returns package metadata for a given `name_normalized` and `version`, plus all other versions available in the repository and all distribution files for that version. Metadata is taken from one representative distribution (sdist preferred). Returns `ErrPythonPackageNotFound` when the package version is not in the repository.
+- **`PythonPackageVersionsGet`** — returns metadata for every version of a given `name_normalized`, each entry matching `PythonPackageGet` for that version. Returns `ErrPythonPackageNotFound` when the package is not in the repository.
 
 Repository href format:
 

--- a/internal/test/integration/python_test.go
+++ b/internal/test/integration/python_test.go
@@ -15,9 +15,12 @@ import (
 )
 
 const (
-	testPythonRepoName = "shelf-reader-fixture"
-	testPythonRepoURL  = "https://pypi.org/"
-	testPythonIncludes = "shelf-reader"
+	testPythonRepoName              = "shelf-reader-fixture"
+	testPythonMultiVersionRepoName  = "idna-multi-version-fixture"
+	testPythonMultiVersionPackage   = "idna"
+	testPythonMultiVersionKeepCount = int64(2)
+	testPythonRepoURL               = "https://pypi.org/"
+	testPythonIncludes              = "shelf-reader"
 )
 
 type PythonSuite struct {
@@ -37,6 +40,7 @@ func (p *PythonSuite) createTestRepository(t *testing.T) {
 		testPythonRepoName,
 		testPythonRepoURL,
 		[]string{testPythonIncludes},
+		0,
 	)
 	require.NoError(t, err)
 
@@ -207,6 +211,67 @@ func (p *PythonSuite) TestPythonPackageGet() {
 		assert.NotZero(p.T(), dist.Size)
 		assert.NotEmpty(p.T(), dist.CreatedAt)
 	}
+}
+
+func (p *PythonSuite) TestPythonPackageVersionsGet() {
+	repoHref, remoteHref, err := p.client.CreateRepository(
+		p.domainName,
+		testPythonMultiVersionRepoName,
+		testPythonRepoURL,
+		[]string{testPythonMultiVersionPackage},
+		testPythonMultiVersionKeepCount,
+	)
+	require.NoError(p.T(), err)
+
+	syncTask, err := p.client.SyncPythonRepository(repoHref, remoteHref)
+	require.NoError(p.T(), err)
+
+	_, err = p.client.PollTask(syncTask)
+	require.NoError(p.T(), err)
+
+	details, err := p.tangy.PythonPackageVersionsGet(
+		context.Background(),
+		repoHref,
+		testPythonMultiVersionPackage,
+	)
+	require.NoError(p.T(), err)
+	require.GreaterOrEqual(p.T(), len(details), 2)
+
+	versions := make([]string, len(details))
+	for i, detail := range details {
+		assert.Equal(p.T(), testPythonMultiVersionPackage, detail.NameNormalized)
+		assert.NotEmpty(p.T(), detail.Name)
+		assert.NotEmpty(p.T(), detail.Version)
+		assert.NotEmpty(p.T(), detail.LastUpdated)
+		require.NotEmpty(p.T(), detail.Distributions)
+
+		for _, dist := range detail.Distributions {
+			assert.Equal(p.T(), testPythonMultiVersionPackage, dist.NameNormalized)
+			assert.Equal(p.T(), detail.Version, dist.Version)
+		}
+
+		versions[i] = detail.Version
+	}
+
+	assert.Len(p.T(), details[0].Versions, len(details))
+	assert.Len(p.T(), details[0].LatestVersions, len(details))
+	assert.Equal(p.T(), details[0].Versions, versions)
+}
+
+func (p *PythonSuite) TestPythonPackageVersionsGetNotFound() {
+	_, err := p.tangy.PythonPackageVersionsGet(
+		context.Background(),
+		p.repositoryHref,
+		"nonexistent-package",
+	)
+	require.Error(p.T(), err)
+	assert.ErrorIs(p.T(), err, tangy.ErrPythonPackageNotFound)
+}
+
+func (p *PythonSuite) TestPythonPackageVersionsGetEmptyHref() {
+	details, err := p.tangy.PythonPackageVersionsGet(context.Background(), "", "shelf-reader")
+	require.NoError(p.T(), err)
+	assert.Nil(p.T(), details)
 }
 
 func (p *PythonSuite) TestPythonPackageGetNotFound() {

--- a/internal/zestwrapper/python.go
+++ b/internal/zestwrapper/python.go
@@ -76,11 +76,14 @@ func (p *PythonZest) LookupDomain(name string) (string, error) {
 	return *list.Results[0].PulpHref, nil
 }
 
-func (p *PythonZest) CreateRepository(domain, name, url string, includes []string) (repoHref string, remoteHref string, err error) {
+func (p *PythonZest) CreateRepository(domain, name, url string, includes []string, keepLatestPackages int64) (repoHref string, remoteHref string, err error) {
 	pythonRemote := zest.NewPythonPythonRemote(name, url)
 	policy := zest.POLICY692ENUM_IMMEDIATE
 	pythonRemote.Policy = &policy
 	pythonRemote.Includes = includes
+	if keepLatestPackages > 0 {
+		pythonRemote.KeepLatestPackages = &keepLatestPackages
+	}
 
 	remoteResponse, httpResp, err := p.client.RemotesPythonAPI.RemotesPythonPythonCreate(p.ctx, domain).
 		PythonPythonRemote(*pythonRemote).Execute()

--- a/pkg/tangy/interface.go
+++ b/pkg/tangy/interface.go
@@ -68,6 +68,7 @@ type Tangy interface {
 	PythonPackageList(ctx context.Context, repositoryHref string, filterOpts PythonPackageListFilters, pageOpts PageOptions) (PythonPackageListResponse, error)
 	PythonDistributionList(ctx context.Context, repositoryHref, nameNormalized, version string, pageOpts PageOptions) (PythonDistributionListResponse, error)
 	PythonPackageGet(ctx context.Context, repositoryHref, nameNormalized, version string) (PythonPackageDetail, error)
+	PythonPackageVersionsGet(ctx context.Context, repositoryHref, nameNormalized string) ([]PythonPackageDetail, error)
 	MavenPackageList(ctx context.Context, repositoryHref string, filterOpts MavenPackageListFilters, pageOpts PageOptions) (MavenPackageListResponse, error)
 	MavenBuildList(ctx context.Context, repositoryHref, groupID, artifactID, version string, pageOpts PageOptions) (MavenBuildListResponse, error)
 	Close()

--- a/pkg/tangy/python.go
+++ b/pkg/tangy/python.go
@@ -304,20 +304,99 @@ func (t *tangyImpl) PythonPackageGet(ctx context.Context, repositoryHref, nameNo
 		return PythonPackageDetail{}, nil
 	}
 
-	conn, err := t.pool.Acquire(ctx)
+	conn, innerUnion, args, err := t.preparePythonPackageQuery(ctx, repositoryHref, nameNormalized)
 	if err != nil {
 		return PythonPackageDetail{}, err
 	}
 	defer conn.Release()
 
+	detailRows, err := fetchPythonPackageDetailRows(ctx, conn, innerUnion, args, version)
+	if err != nil {
+		return PythonPackageDetail{}, err
+	}
+	if len(detailRows) == 0 {
+		return PythonPackageDetail{}, fmt.Errorf("%w: %s@%s", ErrPythonPackageNotFound, nameNormalized, version)
+	}
+
+	row := detailRows[0]
+
+	latestVersions, err := parsePythonLatestVersionsJSON(row.LatestVersionsJSON)
+	if err != nil {
+		return PythonPackageDetail{}, err
+	}
+
+	distributions, err := fetchPythonDistributionRows(ctx, conn, innerUnion, args, 0, 0)
+	if err != nil {
+		return PythonPackageDetail{}, err
+	}
+
+	return pythonPackageDetailFromRow(row, latestVersions, pythonDistributionRowsToItems(distributions)), nil
+}
+
+// PythonPackageVersionsGet returns metadata for every version of a package name_normalized
+// from the latest version of a repository. Metadata for each version is taken from one
+// representative distribution (sdist preferred, then most recently synced).
+func (t *tangyImpl) PythonPackageVersionsGet(ctx context.Context, repositoryHref, nameNormalized string) ([]PythonPackageDetail, error) {
+	if repositoryHref == "" {
+		return nil, nil
+	}
+
+	conn, innerUnion, args, err := t.preparePythonPackageQuery(ctx, repositoryHref, nameNormalized)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Release()
+
+	detailRows, err := fetchPythonPackageDetailRows(ctx, conn, innerUnion, args, "")
+	if err != nil {
+		return nil, err
+	}
+	if len(detailRows) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrPythonPackageNotFound, nameNormalized)
+	}
+
+	latestVersions, err := parsePythonLatestVersionsJSON(detailRows[0].LatestVersionsJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	allDistributions, err := fetchAllPythonDistributionRowsForPackage(ctx, conn, innerUnion, args)
+	if err != nil {
+		return nil, err
+	}
+
+	distributionsByVersion := make(map[string][]PythonDistributionListItem)
+	for _, dist := range allDistributions {
+		distributionsByVersion[dist.Version] = append(
+			distributionsByVersion[dist.Version],
+			pythonDistributionRowToItem(dist),
+		)
+	}
+
+	results := make([]PythonPackageDetail, len(detailRows))
+	for i, row := range detailRows {
+		results[i] = pythonPackageDetailFromRow(row, latestVersions, distributionsByVersion[row.Version])
+	}
+
+	return results, nil
+}
+
+func (t *tangyImpl) preparePythonPackageQuery(ctx context.Context, repositoryHref, nameNormalized string) (*pgxpool.Conn, string, pgx.NamedArgs, error) {
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
 	repoUUID, err := parsePythonRepositoryHref(repositoryHref)
 	if err != nil {
-		return PythonPackageDetail{}, fmt.Errorf("error parsing repository href: %w", err)
+		conn.Release()
+		return nil, "", nil, fmt.Errorf("error parsing repository href: %w", err)
 	}
 
 	latestVersion, err := getLatestPythonRepositoryVersion(ctx, conn, repoUUID)
 	if err != nil {
-		return PythonPackageDetail{}, fmt.Errorf("error getting latest repository version: %w", err)
+		conn.Release()
+		return nil, "", nil, fmt.Errorf("error getting latest repository version: %w", err)
 	}
 
 	repoVerMap := []ParsedRepoVersion{{
@@ -327,11 +406,23 @@ func (t *tangyImpl) PythonPackageGet(ctx context.Context, repositoryHref, nameNo
 
 	args := pgx.NamedArgs{
 		"name_normalized": nameNormalized,
-		"version":         version,
 	}
 	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
 	if err != nil {
-		return PythonPackageDetail{}, err
+		conn.Release()
+		return nil, "", nil, err
+	}
+
+	return conn, innerUnion, args, nil
+}
+
+func fetchPythonPackageDetailRows(ctx context.Context, conn *pgxpool.Conn, innerUnion string, args pgx.NamedArgs, version string) ([]pythonPackageDetailRow, error) {
+	detailFilter := ""
+	orderBy := "ORDER BY d.version"
+	if version != "" {
+		args["version"] = version
+		detailFilter = "WHERE f.version = @version"
+		orderBy = ""
 	}
 
 	query := `
@@ -365,13 +456,14 @@ func (t *tangyImpl) PythonPackageGet(ctx context.Context, repositoryHref, nameNo
 		),
 		detail AS (
 			SELECT f.*,
-			       MAX(f.pulp_created) OVER () AS last_updated,
+			       MAX(f.pulp_created) OVER (PARTITION BY f.version) AS last_updated,
 			       ROW_NUMBER() OVER (
+			           PARTITION BY f.version
 			           ORDER BY CASE WHEN f.packagetype = 'sdist' THEN 0 ELSE 1 END,
 			                    f.pulp_created DESC
 			       ) AS rn
 			FROM filtered f
-			WHERE f.version = @version
+			` + detailFilter + `
 		)
 		SELECT d.name, d.name_normalized, d.version, d.summary, d.description,
 		       d.description_content_type, d.author, d.author_email,
@@ -381,31 +473,18 @@ func (t *tangyImpl) PythonPackageGet(ctx context.Context, repositoryHref, nameNo
 		       d.last_updated, va.versions, va.latest_versions_json
 		FROM detail d
 		CROSS JOIN version_agg va
-		WHERE d.rn = 1`
+		WHERE d.rn = 1
+		` + orderBy
 
 	rows, err := conn.Query(ctx, query, args)
 	if err != nil {
-		return PythonPackageDetail{}, err
+		return nil, err
 	}
 
-	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[pythonPackageDetailRow])
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return PythonPackageDetail{}, fmt.Errorf("%w: %s@%s", ErrPythonPackageNotFound, nameNormalized, version)
-		}
-		return PythonPackageDetail{}, err
-	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[pythonPackageDetailRow])
+}
 
-	latestVersions, err := parsePythonLatestVersionsJSON(row.LatestVersionsJSON)
-	if err != nil {
-		return PythonPackageDetail{}, err
-	}
-
-	distributions, err := fetchPythonDistributionRows(ctx, conn, innerUnion, args, 0, 0)
-	if err != nil {
-		return PythonPackageDetail{}, err
-	}
-
+func pythonPackageDetailFromRow(row pythonPackageDetailRow, latestVersions []PythonVersionInfo, distributions []PythonDistributionListItem) PythonPackageDetail {
 	return PythonPackageDetail{
 		Name:                   row.Name,
 		NameNormalized:         row.NameNormalized,
@@ -429,8 +508,8 @@ func (t *tangyImpl) PythonPackageGet(ctx context.Context, repositoryHref, nameNo
 		LastUpdated:            row.LastUpdated.Format(time.RFC3339),
 		Versions:               row.Versions,
 		LatestVersions:         latestVersions,
-		Distributions:          pythonDistributionRowsToItems(distributions),
-	}, nil
+		Distributions:          distributions,
+	}
 }
 
 func fetchPythonDistributionRows(ctx context.Context, conn *pgxpool.Conn, innerUnion string, args pgx.NamedArgs, limit, offset int) ([]pythonDistributionRow, error) {
@@ -459,22 +538,44 @@ func fetchPythonDistributionRows(ctx context.Context, conn *pgxpool.Conn, innerU
 	return pgx.CollectRows(rows, pgx.RowToStructByName[pythonDistributionRow])
 }
 
+func pythonDistributionRowToItem(dist pythonDistributionRow) PythonDistributionListItem {
+	return PythonDistributionListItem{
+		Name:           dist.Name,
+		NameNormalized: dist.NameNormalized,
+		Version:        dist.Version,
+		Filename:       dist.Filename,
+		PackageType:    dist.PackageType,
+		PythonVersion:  dist.PythonVersion,
+		Sha256:         dist.Sha256,
+		Size:           dist.Size,
+		CreatedAt:      dist.CreatedAt.Format(time.RFC3339),
+	}
+}
+
 func pythonDistributionRowsToItems(distributions []pythonDistributionRow) []PythonDistributionListItem {
 	results := make([]PythonDistributionListItem, len(distributions))
 	for i, dist := range distributions {
-		results[i] = PythonDistributionListItem{
-			Name:           dist.Name,
-			NameNormalized: dist.NameNormalized,
-			Version:        dist.Version,
-			Filename:       dist.Filename,
-			PackageType:    dist.PackageType,
-			PythonVersion:  dist.PythonVersion,
-			Sha256:         dist.Sha256,
-			Size:           dist.Size,
-			CreatedAt:      dist.CreatedAt.Format(time.RFC3339),
-		}
+		results[i] = pythonDistributionRowToItem(dist)
 	}
 	return results
+}
+
+func fetchAllPythonDistributionRowsForPackage(ctx context.Context, conn *pgxpool.Conn, innerUnion string, args pgx.NamedArgs) ([]pythonDistributionRow, error) {
+	query := `
+		SELECT rp.name, rp.name_normalized, rp.version, rp.filename, rp.packagetype,
+		       rp.python_version, rp.sha256, rp.size, cc.pulp_created AS created_at
+		FROM python_pythonpackagecontent rp
+		INNER JOIN core_content cc ON rp.content_ptr_id = cc.pulp_id
+	` + innerUnion + `
+		AND rp.name_normalized = @name_normalized
+		ORDER BY rp.version, cc.pulp_created DESC`
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return nil, err
+	}
+
+	return pgx.CollectRows(rows, pgx.RowToStructByName[pythonDistributionRow])
 }
 
 func parsePythonLatestVersionsJSON(data []byte) ([]PythonVersionInfo, error) {

--- a/pkg/tangy/python_test.go
+++ b/pkg/tangy/python_test.go
@@ -249,6 +249,47 @@ func TestMockTangyPythonPackageGet(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
+func TestMockTangyPythonPackageVersionsGet(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+
+	expected := []PythonPackageDetail{
+		{
+			Name:           "Django",
+			NameNormalized: "django",
+			Version:        "4.2",
+			Summary:        "A high-level Python web framework",
+			LastUpdated:    "2023-01-01T12:00:00Z",
+			Versions:       []string{"4.2", "5.0"},
+			LatestVersions: []PythonVersionInfo{
+				{Version: "4.2", CreatedAt: "2023-01-01T12:00:00Z"},
+				{Version: "5.0", CreatedAt: "2024-01-01T12:00:00Z"},
+			},
+		},
+		{
+			Name:           "Django",
+			NameNormalized: "django",
+			Version:        "5.0",
+			Summary:        "A high-level Python web framework",
+			LastUpdated:    "2024-01-01T12:00:00Z",
+			Versions:       []string{"4.2", "5.0"},
+			LatestVersions: []PythonVersionInfo{
+				{Version: "4.2", CreatedAt: "2023-01-01T12:00:00Z"},
+				{Version: "5.0", CreatedAt: "2024-01-01T12:00:00Z"},
+			},
+		},
+	}
+
+	mockTangy.On("PythonPackageVersionsGet", ctx, repoHref, "django").Return(expected, nil)
+
+	got, err := mockTangy.PythonPackageVersionsGet(ctx, repoHref, "django")
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
 func TestParsePythonJSONStringSlice(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tangy/tangy_mock.go
+++ b/pkg/tangy/tangy_mock.go
@@ -478,6 +478,80 @@ func (_c *MockTangy_PythonPackageList_Call) RunAndReturn(run func(ctx context.Co
 	return _c
 }
 
+// PythonPackageVersionsGet provides a mock function for the type MockTangy
+func (_mock *MockTangy) PythonPackageVersionsGet(ctx context.Context, repositoryHref string, nameNormalized string) ([]PythonPackageDetail, error) {
+	ret := _mock.Called(ctx, repositoryHref, nameNormalized)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PythonPackageVersionsGet")
+	}
+
+	var r0 []PythonPackageDetail
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]PythonPackageDetail, error)); ok {
+		return returnFunc(ctx, repositoryHref, nameNormalized)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []PythonPackageDetail); ok {
+		r0 = returnFunc(ctx, repositoryHref, nameNormalized)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]PythonPackageDetail)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, repositoryHref, nameNormalized)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTangy_PythonPackageVersionsGet_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PythonPackageVersionsGet'
+type MockTangy_PythonPackageVersionsGet_Call struct {
+	*mock.Call
+}
+
+// PythonPackageVersionsGet is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repositoryHref string
+//   - nameNormalized string
+func (_e *MockTangy_Expecter) PythonPackageVersionsGet(ctx any, repositoryHref any, nameNormalized any) *MockTangy_PythonPackageVersionsGet_Call {
+	return &MockTangy_PythonPackageVersionsGet_Call{Call: _e.mock.On("PythonPackageVersionsGet", ctx, repositoryHref, nameNormalized)}
+}
+
+func (_c *MockTangy_PythonPackageVersionsGet_Call) Run(run func(ctx context.Context, repositoryHref string, nameNormalized string)) *MockTangy_PythonPackageVersionsGet_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTangy_PythonPackageVersionsGet_Call) Return(pythonPackageDetails []PythonPackageDetail, err error) *MockTangy_PythonPackageVersionsGet_Call {
+	_c.Call.Return(pythonPackageDetails, err)
+	return _c
+}
+
+func (_c *MockTangy_PythonPackageVersionsGet_Call) RunAndReturn(run func(ctx context.Context, repositoryHref string, nameNormalized string) ([]PythonPackageDetail, error)) *MockTangy_PythonPackageVersionsGet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RpmRepositoryVersionEnvironmentSearch provides a mock function for the type MockTangy
 func (_mock *MockTangy) RpmRepositoryVersionEnvironmentSearch(ctx context.Context, hrefs []string, search string, limit int) ([]RpmEnvironmentSearch, error) {
 	ret := _mock.Called(ctx, hrefs, search, limit)


### PR DESCRIPTION
This PR:
- Adds `PythonPackageVersionsGet` to return package details for every version by name
- Refactors `PythonPackageGet/VersionsGet` to share query setup and detail SQL
- Adds unit, mock, and integration tests including a multi-version idna fixture
- Documents the new API and extends `CreateRepository` with `keepLatestPackages`