### PR TITLE
HMS-10970: extract author from email if author is empty

### DIFF
--- a/internal/test/integration/python_test.go
+++ b/internal/test/integration/python_test.go
@@ -188,6 +188,8 @@ func (p *PythonSuite) TestPythonPackageGet() {
 	assert.Equal(p.T(), "shelf-reader", detail.NameNormalized)
 	assert.Equal(p.T(), "0.1", detail.Version)
 	assert.NotEmpty(p.T(), detail.Name)
+	assert.Equal(p.T(), "Austin Macdonald", detail.Author)
+	assert.Equal(p.T(), "asmacdo@gmail.com", detail.AuthorEmail)
 	assert.NotEmpty(p.T(), detail.LastUpdated)
 	assert.Contains(p.T(), detail.Versions, "0.1")
 	require.NotEmpty(p.T(), detail.LatestVersions)
@@ -243,6 +245,8 @@ func (p *PythonSuite) TestPythonPackageVersionsGet() {
 		assert.NotEmpty(p.T(), detail.Name)
 		assert.NotEmpty(p.T(), detail.Version)
 		assert.NotEmpty(p.T(), detail.LastUpdated)
+		assert.Equal(p.T(), "Kim Davies", detail.Author)
+		assert.Equal(p.T(), "Kim Davies <kim+pypi@gumleaf.org>", detail.AuthorEmail)
 		require.NotEmpty(p.T(), detail.Distributions)
 
 		for _, dist := range detail.Distributions {

--- a/pkg/tangy/python.go
+++ b/pkg/tangy/python.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/mail"
 	"strings"
 	"time"
 
@@ -492,7 +493,7 @@ func pythonPackageDetailFromRow(row pythonPackageDetailRow, latestVersions []Pyt
 		Summary:                row.Summary,
 		Description:            row.Description,
 		DescriptionContentType: row.DescriptionContentType,
-		Author:                 row.Author,
+		Author:                 parsePythonAuthor(row.Author, row.AuthorEmail),
 		AuthorEmail:            row.AuthorEmail,
 		Maintainer:             row.Maintainer,
 		MaintainerEmail:        row.MaintainerEmail,
@@ -599,6 +600,24 @@ func parsePythonLatestVersionsJSON(data []byte) ([]PythonVersionInfo, error) {
 		}
 	}
 	return latestVersions, nil
+}
+
+func parsePythonAuthor(author, authorEmail string) string {
+	if strings.TrimSpace(author) != "" {
+		return author
+	}
+
+	authorEmail = strings.TrimSpace(authorEmail)
+	if authorEmail == "" {
+		return author
+	}
+
+	addr, err := mail.ParseAddress(authorEmail)
+	if err != nil || addr.Name == "" {
+		return author
+	}
+
+	return addr.Name
 }
 
 func parsePythonJSONStringSlice(data []byte) []string {

--- a/pkg/tangy/python_test.go
+++ b/pkg/tangy/python_test.go
@@ -290,6 +290,56 @@ func TestMockTangyPythonPackageVersionsGet(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
+func TestParsePythonAuthor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		author      string
+		authorEmail string
+		want        string
+	}{
+		{
+			name:        "author already set",
+			author:      "Django Software Foundation",
+			authorEmail: "Django Software Foundation <foundation@djangoproject.com>",
+			want:        "Django Software Foundation",
+		},
+		{
+			name:        "extract name from email",
+			author:      "",
+			authorEmail: "Google LLC <googleapis-packages@google.com>",
+			want:        "Google LLC",
+		},
+		{
+			name:        "email only",
+			author:      "",
+			authorEmail: "googleapis-packages@google.com",
+			want:        "",
+		},
+		{
+			name:        "both empty",
+			author:      "",
+			authorEmail: "",
+			want:        "",
+		},
+		{
+			name:        "whitespace author extracts from email",
+			author:      "   ",
+			authorEmail: "Google LLC <googleapis-packages@google.com>",
+			want:        "Google LLC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, parsePythonAuthor(tt.author, tt.authorEmail))
+		})
+	}
+}
+
 func TestParsePythonJSONStringSlice(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR:
- Extracts author name from `author_email` when author is empty (RFC 5322 parsing)
- Leaves `author_email` unchanged; existing `author` field takes precedence
- Adds unit tests for `parsePythonAuthor` and integration checks for `shelf-reader/idna`