### PR TITLE
HMS-10971: update zest, fix small issues, add unit and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ CONFIG_PATH="$(pwd)/configs/" go test ./internal/test/integration/ -run TestRpmS
 CONFIG_PATH="$(pwd)/configs/" go test ./internal/test/integration/ -run TestMavenSuite -v
 ```
 
-The Python integration test syncs `shelf-reader` from PyPI into a random domain via the Pulp API, then asserts tangy can read it from the database. The Maven integration test pull-through caches `junit:junit:4.13.2` from Maven Central, adds the cached content to a repository, then asserts tangy can read it from the database. Test data is left in the database after a run; use `make compose-clean` to wipe volumes and start fresh.
+The Python integration test syncs `shelf-reader` from PyPI into a random domain via the Pulp API, then asserts tangy can read it from the database. The Maven integration test pull-through caches `junit:junit:4.13.2` from a local nginx fixture in the compose stack (avoids Maven Central rate limits in CI), adds the cached content to a repository, then asserts tangy can read it from the database. Test data is left in the database after a run; use `make compose-clean` to wipe volumes and start fresh.
 
 ### Mocking
 Tangy also exports a mock interface you can regenerate using the [mockery](https://github.com/vektra/mockery) tool.

--- a/README.md
+++ b/README.md
@@ -171,9 +171,10 @@ Or run a specific suite:
 ```bash
 CONFIG_PATH="$(pwd)/configs/" go test ./internal/test/integration/ -run TestPythonSuite -v
 CONFIG_PATH="$(pwd)/configs/" go test ./internal/test/integration/ -run TestRpmSuite -v
+CONFIG_PATH="$(pwd)/configs/" go test ./internal/test/integration/ -run TestMavenSuite -v
 ```
 
-The Python integration test syncs `shelf-reader` from PyPI into a random domain via the Pulp API, then asserts tangy can read it from the database. Test data is left in the database after a run; use `make compose-clean` to wipe volumes and start fresh.
+The Python integration test syncs `shelf-reader` from PyPI into a random domain via the Pulp API, then asserts tangy can read it from the database. The Maven integration test pull-through caches `junit:junit:4.13.2` from Maven Central, adds the cached content to a repository, then asserts tangy can read it from the database. Test data is left in the database after a run; use `make compose-clean` to wipe volumes and start fresh.
 
 ### Mocking
 Tangy also exports a mock interface you can regenerate using the [mockery](https://github.com/vektra/mockery) tool.

--- a/compose_files/pulp/assets/maven-fixture/junit/junit/4.13.2/junit-4.13.2.pom
+++ b/compose_files/pulp/assets/maven-fixture/junit/junit/4.13.2/junit-4.13.2.pom
@@ -1,0 +1,633 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.13.2</version>
+
+    <name>JUnit</name>
+    <description>JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.</description>
+    <url>http://junit.org</url>
+    <inceptionYear>2002</inceptionYear>
+    <organization>
+        <name>JUnit</name>
+        <url>http://www.junit.org</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>Eclipse Public License 1.0</name>
+            <url>http://www.eclipse.org/legal/epl-v10.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>dsaff</id>
+            <name>David Saff</name>
+            <email>david@saff.net</email>
+        </developer>
+        <developer>
+            <id>kcooney</id>
+            <name>Kevin Cooney</name>
+            <email>kcooney@google.com</email>
+        </developer>
+        <developer>
+            <id>stefanbirkner</id>
+            <name>Stefan Birkner</name>
+            <email>mail@stefan-birkner.de</email>
+        </developer>
+        <developer>
+            <id>marcphilipp</id>
+            <name>Marc Philipp</name>
+            <email>mail@marcphilipp.de</email>
+        </developer>
+    </developers>
+    <contributors>
+        <contributor>
+            <name>JUnit contributors</name>
+            <organization>JUnit</organization>
+            <email>team@junit.org</email>
+            <url>https://github.com/junit-team/junit4/graphs/contributors</url>
+            <roles>
+                <role>developers</role>
+            </roles>
+        </contributor>
+    </contributors>
+
+    <prerequisites>
+        <maven>3.0.4</maven>
+    </prerequisites>
+
+    <scm>
+        <connection>scm:git:git://github.com/junit-team/junit4.git</connection>
+        <developerConnection>scm:git:git@github.com:junit-team/junit4.git</developerConnection>
+        <url>https://github.com/junit-team/junit4</url>
+      <tag>r4.13.2</tag>
+  </scm>
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/junit-team/junit4/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>github</system>
+        <url>https://github.com/junit-team/junit4/actions</url>
+    </ciManagement>
+    <distributionManagement>
+        <downloadUrl>https://github.com/junit-team/junit4/wiki/Download-and-Install</downloadUrl>
+        <snapshotRepository>
+            <id>junit-snapshot-repo</id>
+            <name>Nexus Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>junit-releases-repo</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <site>
+            <id>junit.github.io</id>
+            <url>gitsite:git@github.com/junit-team/junit4.git</url>
+        </site>
+    </distributionManagement>
+
+    <properties>
+        <jdkVersion>1.5</jdkVersion>
+        <surefireVersion>2.19.1</surefireVersion>
+        <hamcrestVersion>1.3</hamcrestVersion>
+        <enforcerPluginVersion>1.4</enforcerPluginVersion>
+        <jarPluginVersion>2.6</jarPluginVersion>
+        <javadocPluginVersion>2.10.3</javadocPluginVersion>
+        <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
+        <arguments />
+        <gpg.keyname>67893CC4</gpg.keyname>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrestVersion}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrestVersion}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>LICENSE-junit.txt</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <!--
+            Both "org.apache" and "org.codehaus" are default providers of MOJO plugins
+            which are especially dedicated to Maven projects.
+            The MOJO stands for "Maven plain Old Java Object".
+            Each mojo is an executable goal in Maven, and a plugin is a distribution of
+            one or more related mojos.
+            For more information see http://maven.apache.org/plugin-developers/index.html
+
+            The following plugins are ordered according the Maven build lifecycle.
+            http://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html
+            -->
+            <plugin>
+                <!--
+                Checks that the version of user's maven installation is 3.0.4,
+                the JDK is 1.5+, no non-standard repositories are specified in
+                the project, requires only release versions of dependencies of other artifacts.
+                -->
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${enforcerPluginVersion}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <fail>true</fail>
+                            <rules>
+                                <requireMavenVersion>
+                                    <!-- Some plugin features require a recent Maven runtime to work properly -->
+                                    <message>Current version of Maven ${maven.version} required to build the project
+                                        should be ${project.prerequisites.maven}, or higher!
+                                    </message>
+                                    <version>[${project.prerequisites.maven},)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <message>Current JDK version ${java.version} should be ${jdkVersion}, or higher!
+                                    </message>
+                                    <version>${jdkVersion}</version>
+                                </requireJavaVersion>
+                                <requireNoRepositories>
+                                    <message>Best Practice is to never define repositories in pom.xml (use a repository
+                                        manager instead).
+                                    </message>
+                                </requireNoRepositories>
+                                <requireReleaseDeps>
+                                    <message>No Snapshots Dependencies Allowed!</message>
+                                </requireReleaseDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                Updates Version#id().
+                -->
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <ignoreMissingFile>false</ignoreMissingFile>
+                    <file>${project.build.sourceDirectory}/junit/runner/Version.java.template</file>
+                    <outputFile>${project.build.sourceDirectory}/junit/runner/Version.java</outputFile>
+                    <regex>false</regex>
+                    <token>@version@</token>
+                    <value>${project.version}</value>
+                </configuration>
+            </plugin>
+            <plugin><!-- Using jdk 1.5.0_22, package-info.java files are compiled correctly. -->
+                <!--
+                java compiler plugin forked in extra process
+                -->
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <source>${jdkVersion}</source>
+                    <target>${jdkVersion}</target>
+                    <testSource>${jdkVersion}</testSource>
+                    <testTarget>${jdkVersion}</testTarget>
+                    <compilerVersion>1.5</compilerVersion>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <debug>true</debug>
+                    <fork>true</fork>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                    <maxmem>128m</maxmem>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.14</version>
+                <executions>
+                    <execution>
+                        <id>signature-check</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <signature>
+                                <groupId>org.codehaus.mojo.signature</groupId>
+                                <artifactId>java15</artifactId>
+                                <version>1.0</version>
+                            </signature>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                A plugin which uses the JUnit framework in order to start
+                our junit suite "AllTests" after the sources are compiled.
+                -->
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefireVersion}</version>
+                <configuration>
+                    <test>org/junit/tests/AllTests.java</test>
+                    <useSystemClassLoader>true</useSystemClassLoader>
+                    <enableAssertions>false</enableAssertions>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${surefireVersion}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin can package the main artifact's sources (src/main/java)
+                in to jar archive. See target/junit-*-sources.jar.
+                -->
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin can generate Javadoc by a forked
+                process and then package the Javadoc
+                in jar archive target/junit-*-javadoc.jar.
+                -->
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${javadocPluginVersion}</version>
+                <configuration>
+                    <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
+                    <show>protected</show>
+                    <author>false</author>
+                    <version>false</version>
+                    <detectLinks>false</detectLinks>
+                    <linksource>true</linksource>
+                    <keywords>true</keywords>
+                    <use>true</use>
+                    <windowtitle>JUnit API</windowtitle>
+                    <encoding>UTF-8</encoding>
+                    <locale>en</locale>
+                    <javadocVersion>${jdkVersion}</javadocVersion>
+                    <javaApiLinks>
+                        <property>
+                            <name>api_${jdkVersion}</name>
+                            <value>http://docs.oracle.com/javase/${jdkVersion}.0/docs/api/</value>
+                        </property>
+                    </javaApiLinks>
+                    <excludePackageNames>*.internal.*</excludePackageNames>
+                    <verbose>true</verbose>
+                    <minmemory>32m</minmemory>
+                    <maxmemory>128m</maxmemory>
+                    <failOnError>true</failOnError>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>
+                        <dependencySourceInclude>org.hamcrest:hamcrest-core:*</dependencySourceInclude>
+                    </dependencySourceIncludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <arguments>-Pgenerate-docs,junit-release ${arguments}</arguments>
+                    <tagNameFormat>r@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.stephenc.wagon</groupId>
+                        <artifactId>wagon-gitsite</artifactId>
+                        <version>0.4.1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.doxia</groupId>
+                        <artifactId>doxia-module-markdown</artifactId>
+                        <version>1.5</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${jarPluginVersion}</version>
+                <configuration>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>junit</Automatic-Module-Name>
+                        </manifestEntries>                        
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>2.6.1</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.5.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                    <!-- waiting for MPIR-267 -->
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>index</report>
+                            <report>dependency-info</report>
+                            <report>modules</report>
+                            <report>license</report>
+                            <report>project-team</report>
+                            <report>scm</report>
+                            <report>issue-tracking</report>
+                            <report>mailing-list</report>
+                            <report>dependency-management</report>
+                            <report>dependencies</report>
+                            <report>dependency-convergence</report>
+                            <report>cim</report>
+                            <report>distribution-management</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${javadocPluginVersion}</version>
+                <configuration>
+                    <destDir>javadoc/latest</destDir>
+                    <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
+                    <show>protected</show>
+                    <author>false</author>
+                    <version>false</version>
+                    <detectLinks>false</detectLinks>
+                    <linksource>true</linksource>
+                    <keywords>true</keywords>
+                    <use>true</use>
+                    <windowtitle>JUnit API</windowtitle>
+                    <encoding>UTF-8</encoding>
+                    <locale>en</locale>
+                    <javadocVersion>${jdkVersion}</javadocVersion>
+                    <javaApiLinks>
+                        <property>
+                            <name>api_${jdkVersion}</name>
+                            <value>http://docs.oracle.com/javase/${jdkVersion}.0/docs/api/</value>
+                        </property>
+                    </javaApiLinks>
+                    <excludePackageNames>junit.*,*.internal.*</excludePackageNames>
+                    <verbose>true</verbose>
+                    <minmemory>32m</minmemory>
+                    <maxmemory>128m</maxmemory>
+                    <failOnError>true</failOnError>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>
+                        <dependencySourceInclude>org.hamcrest:hamcrest-core:*</dependencySourceInclude>
+                    </dependencySourceIncludes>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+
+    <profiles>
+        <profile>
+            <id>junit-release</id>
+            <!--
+            Signs all artifacts before deploying to Maven Central.
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <!--
+                        The goal is to sign all artifacts so that the user may verify them before downloading.
+                        The automatic build system may reuire your key ID, and passphrase specified using system properties:
+                        -Dgpg.passphrase="<passphrase>" -Dgpg.keyname="<your key ID>"
+                        In order to create the key pair, use the command "gpg &ndash;&ndash;gen-key".
+                        (&ndash;&ndash; stands for double dash)
+                        -->
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>gpg-sign</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>generate-docs</id>
+            <!--
+            Generate the documentation artifacts. 
+            Note: this profile is also required to be active for release
+            builds due to the packaging requirements of the Central repo
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>restrict-doclint</id>
+            <!-- doclint is only supported by JDK 8 -->
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xlint:unchecked</arg>
+                                <arg>-Xdoclint:accessibility,reference,syntax</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:accessibility -Xdoclint:reference</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:accessibility -Xdoclint:reference</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+        <profile>
+            <id>java9</id>
+            <activation>
+                <jdk>[1.9,12)</jdk>
+            </activation>
+            <properties>
+                <!-- JDK 9 minimal source and target versions are 1.6 -->
+                <jdkVersion>1.6</jdkVersion>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <source>1.6</source>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <source>1.6</source>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+        <profile>
+            <id>java12</id>
+            <activation>
+                <jdk>[12,)</jdk>
+            </activation>
+            <properties>
+                <!-- JDK 12 minimal source and target versions are 1.7 -->
+                <jdkVersion>1.7</jdkVersion>
+                <enforcerPluginVersion>3.0.0-M3</enforcerPluginVersion>
+                <jarPluginVersion>3.2.0</jarPluginVersion>
+                <javadocPluginVersion>3.2.0</javadocPluginVersion>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <source>1.7</source>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xdoclint:none</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <source>1.7</source>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+    </profiles>
+</project>

--- a/compose_files/pulp/docker-compose.yml
+++ b/compose_files/pulp/docker-compose.yml
@@ -54,6 +54,12 @@ services:
     healthcheck:
       test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
 
+  maven_fixture:
+    image: "docker.io/library/nginx:alpine"
+    volumes:
+      - "./assets/maven-fixture:/usr/share/nginx/html:ro"
+    restart: always
+
   pulp_api:
     image: "quay.io/redhat-services-prod/pulp-services-tenant/pulp:latest"
     platform: linux/amd64

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/content-services/tang
 go 1.24.0
 
 require (
-	github.com/content-services/zest/release/v2024 v2024.12.1734541842
+	github.com/content-services/zest/release/v2026 v2026.7.1783082453
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb
 	github.com/jackc/pgx/v5 v5.7.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/content-services/zest/release/v2024 v2024.12.1734541842 h1:vIIWFZ5j76MVg2VuxkXAR56NAvkst7LtAeAugbfJmFU=
-github.com/content-services/zest/release/v2024 v2024.12.1734541842/go.mod h1:fUWkjhvNTiS9UaaAWNLYkshl37V9IVmmRaprp9eDmrU=
+github.com/content-services/zest/release/v2026 v2026.7.1783082453 h1:mZ8LExJlcMcoIUCv7eW+qQwZ9in18byKtuA99WWG0+M=
+github.com/content-services/zest/release/v2026 v2026.7.1783082453/go.mod h1:pThh4a5Qm53BZ5V3WqRkWx7WBrIaeDdAnTmmqi6j8Vw=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/test/integration/maven_test.go
+++ b/internal/test/integration/maven_test.go
@@ -1,0 +1,266 @@
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/content-services/tang/internal/config"
+	"github.com/content-services/tang/internal/zestwrapper"
+	"github.com/content-services/tang/pkg/tangy"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testMavenRepoName             = "junit-fixture"
+	testMavenDistributionBasePath = "junit-fixture"
+	testMavenRemoteURL            = "http://maven_fixture/"
+	testMavenContentOrigin        = "http://localhost:8088"
+	testMavenGroupID              = "junit"
+	testMavenArtifactID           = "junit"
+	testMavenVersion              = "4.13.2"
+	testMavenPomPath              = "junit/junit/4.13.2/junit-4.13.2.pom"
+)
+
+type MavenSuite struct {
+	suite.Suite
+	client         *zestwrapper.MavenZest
+	tangy          tangy.Tangy
+	domainName     string
+	repositoryHref string
+}
+
+func (m *MavenSuite) createTestRepository(t *testing.T) {
+	_, err := m.client.LookupOrCreateDomain(m.domainName)
+	require.NoError(t, err)
+
+	repoHref, remoteHref, err := m.client.CreateRepository(
+		m.domainName,
+		testMavenRepoName,
+		testMavenRemoteURL,
+		testMavenDistributionBasePath,
+	)
+	require.NoError(t, err)
+
+	err = m.client.FetchArtifact(testMavenContentOrigin, m.domainName, testMavenDistributionBasePath, testMavenPomPath)
+	require.NoError(t, err)
+
+	addTask, err := m.client.AddCachedContent(repoHref, remoteHref)
+	require.NoError(t, err)
+
+	_, err = m.client.PollTask(addTask)
+	require.NoError(t, err)
+
+	m.repositoryHref = repoHref
+}
+
+func TestMavenSuite(t *testing.T) {
+	s := config.Get().Server
+	mavenZest := zestwrapper.NewMavenZest(context.Background(), s)
+
+	dbConfig := config.Get().Database
+	ta, err := tangy.New(tangy.Database{
+		Name:     dbConfig.Name,
+		Host:     dbConfig.Host,
+		Port:     dbConfig.Port,
+		User:     dbConfig.User,
+		Password: dbConfig.Password,
+	}, tangy.Logger{Enabled: true, Logger: &log.Logger, LogLevel: zerolog.LevelDebugValue})
+	require.NoError(t, err)
+	t.Cleanup(ta.Close)
+
+	m := MavenSuite{}
+	m.client = &mavenZest
+	m.tangy = ta
+	m.domainName = RandStringBytes(10)
+
+	m.createTestRepository(t)
+
+	suite.Run(t, &m)
+}
+
+func (m *MavenSuite) TestMavenPackageList() {
+	response, err := m.tangy.MavenPackageList(context.Background(), m.repositoryHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{
+		Offset: 0,
+		Limit:  10,
+	})
+	require.NoError(m.T(), err)
+	require.NotEmpty(m.T(), response.Results)
+	assert.Equal(m.T(), 1, response.Total)
+
+	pkg := response.Results[0]
+	assert.Equal(m.T(), testMavenGroupID, pkg.GroupID)
+	assert.Equal(m.T(), testMavenArtifactID, pkg.ArtifactID)
+	assert.Contains(m.T(), pkg.Versions, testMavenVersion)
+	require.NotEmpty(m.T(), pkg.LatestReleases)
+
+	foundVersion := false
+	for _, latest := range pkg.LatestReleases {
+		if latest.Version == testMavenVersion {
+			foundVersion = true
+			assert.NotEmpty(m.T(), latest.CreatedAt)
+		}
+	}
+	assert.True(m.T(), foundVersion)
+}
+
+func (m *MavenSuite) TestMavenPackageListSearchFilter() {
+	response, err := m.tangy.MavenPackageList(context.Background(), m.repositoryHref, tangy.MavenPackageListFilters{Search: "junit"}, tangy.PageOptions{
+		Offset: 0,
+		Limit:  10,
+	})
+	require.NoError(m.T(), err)
+	require.NotEmpty(m.T(), response.Results)
+	assert.Equal(m.T(), 1, response.Total)
+	assert.Equal(m.T(), testMavenArtifactID, response.Results[0].ArtifactID)
+
+	response, err = m.tangy.MavenPackageList(context.Background(), m.repositoryHref, tangy.MavenPackageListFilters{Search: "nonexistent-artifact"}, tangy.PageOptions{
+		Offset: 0,
+		Limit:  10,
+	})
+	require.NoError(m.T(), err)
+	assert.Empty(m.T(), response.Results)
+	assert.Zero(m.T(), response.Total)
+}
+
+func (m *MavenSuite) TestMavenPackageListPagination() {
+	response, err := m.tangy.MavenPackageList(context.Background(), m.repositoryHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{
+		Offset: 0,
+		Limit:  1,
+	})
+	require.NoError(m.T(), err)
+	assert.Len(m.T(), response.Results, 1)
+	assert.Equal(m.T(), 1, response.Total)
+	assert.Equal(m.T(), 1, response.Limit)
+
+	response, err = m.tangy.MavenPackageList(context.Background(), m.repositoryHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{
+		Offset: 1,
+		Limit:  1,
+	})
+	require.NoError(m.T(), err)
+	assert.Empty(m.T(), response.Results)
+	assert.Equal(m.T(), 1, response.Total)
+}
+
+func (m *MavenSuite) TestMavenPackageListEmptyHref() {
+	response, err := m.tangy.MavenPackageList(context.Background(), "", tangy.MavenPackageListFilters{}, tangy.PageOptions{Limit: 10})
+	require.NoError(m.T(), err)
+	assert.Empty(m.T(), response.Results)
+	assert.Zero(m.T(), response.Total)
+}
+
+func (m *MavenSuite) TestMavenBuildList() {
+	response, err := m.tangy.MavenBuildList(
+		context.Background(),
+		m.repositoryHref,
+		testMavenGroupID,
+		testMavenArtifactID,
+		testMavenVersion,
+		tangy.PageOptions{Offset: 0, Limit: 10},
+	)
+	require.NoError(m.T(), err)
+	require.NotEmpty(m.T(), response.Results)
+	assert.Equal(m.T(), 1, response.Total)
+	assert.Equal(m.T(), 10, response.Limit)
+
+	build := response.Results[0]
+	assert.Equal(m.T(), testMavenGroupID, build.GroupID)
+	assert.Equal(m.T(), testMavenArtifactID, build.ArtifactID)
+	assert.Equal(m.T(), testMavenVersion, build.Version)
+	assert.True(m.T(), strings.HasSuffix(build.Filename, ".pom"), build.Filename)
+	assert.NotEmpty(m.T(), build.CreatedAt)
+}
+
+func (m *MavenSuite) TestMavenBuildListPagination() {
+	response, err := m.tangy.MavenBuildList(
+		context.Background(),
+		m.repositoryHref,
+		testMavenGroupID,
+		testMavenArtifactID,
+		testMavenVersion,
+		tangy.PageOptions{Offset: 0, Limit: 1},
+	)
+	require.NoError(m.T(), err)
+	assert.Len(m.T(), response.Results, 1)
+	assert.Equal(m.T(), 1, response.Total)
+
+	response, err = m.tangy.MavenBuildList(
+		context.Background(),
+		m.repositoryHref,
+		testMavenGroupID,
+		testMavenArtifactID,
+		testMavenVersion,
+		tangy.PageOptions{Offset: 1, Limit: 10},
+	)
+	require.NoError(m.T(), err)
+	assert.Empty(m.T(), response.Results)
+	assert.Equal(m.T(), 1, response.Total)
+}
+
+func (m *MavenSuite) TestMavenBuildListEmptyHref() {
+	response, err := m.tangy.MavenBuildList(context.Background(), "", testMavenGroupID, testMavenArtifactID, testMavenVersion, tangy.PageOptions{Limit: 10})
+	require.NoError(m.T(), err)
+	assert.Empty(m.T(), response.Results)
+	assert.Zero(m.T(), response.Total)
+}
+
+func (m *MavenSuite) TestMavenBuildListOptionalFilters() {
+	response, err := m.tangy.MavenBuildList(
+		context.Background(),
+		m.repositoryHref,
+		"",
+		"",
+		"",
+		tangy.PageOptions{Offset: 0, Limit: 10},
+	)
+	require.NoError(m.T(), err)
+	require.NotEmpty(m.T(), response.Results)
+	assert.Equal(m.T(), 1, response.Total)
+
+	build := response.Results[0]
+	assert.Equal(m.T(), testMavenGroupID, build.GroupID)
+	assert.Equal(m.T(), testMavenArtifactID, build.ArtifactID)
+	assert.Equal(m.T(), testMavenVersion, build.Version)
+
+	filtered, err := m.tangy.MavenBuildList(
+		context.Background(),
+		m.repositoryHref,
+		testMavenGroupID,
+		"",
+		"",
+		tangy.PageOptions{Offset: 0, Limit: 10},
+	)
+	require.NoError(m.T(), err)
+	require.Len(m.T(), filtered.Results, 1)
+	assert.Equal(m.T(), 1, filtered.Total)
+
+	filtered, err = m.tangy.MavenBuildList(
+		context.Background(),
+		m.repositoryHref,
+		"",
+		testMavenArtifactID,
+		"",
+		tangy.PageOptions{Offset: 0, Limit: 10},
+	)
+	require.NoError(m.T(), err)
+	require.Len(m.T(), filtered.Results, 1)
+	assert.Equal(m.T(), 1, filtered.Total)
+}
+
+func (m *MavenSuite) TestMavenRepositoryMetrics() {
+	metrics, err := m.tangy.MavenRepositoryMetrics(context.Background(), m.repositoryHref)
+	require.NoError(m.T(), err)
+	assert.Equal(m.T(), 1, metrics.PackageCount)
+	assert.Equal(m.T(), 1, metrics.BuildCount)
+}
+
+func (m *MavenSuite) TestMavenRepositoryMetricsEmptyHref() {
+	metrics, err := m.tangy.MavenRepositoryMetrics(context.Background(), "")
+	require.NoError(m.T(), err)
+	assert.Zero(m.T(), metrics.PackageCount)
+	assert.Zero(m.T(), metrics.BuildCount)
+}

--- a/internal/zestwrapper/href.go
+++ b/internal/zestwrapper/href.go
@@ -1,0 +1,11 @@
+package zestwrapper
+
+import "strings"
+
+// normalizePulpHref strips a leading slash from Pulp resource hrefs before they are
+// embedded in zest URL paths. Zest v2026 builds paths as baseURL + "/" + href, so hrefs
+// returned by Pulp (e.g. "/api/pulp/default/api/v3/...") would otherwise produce a
+// double slash and 404 responses.
+func normalizePulpHref(href string) string {
+	return strings.TrimPrefix(href, "/")
+}

--- a/internal/zestwrapper/href_test.go
+++ b/internal/zestwrapper/href_test.go
@@ -1,0 +1,33 @@
+package zestwrapper
+
+import "testing"
+
+func TestNormalizePulpHref(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		href string
+		want string
+	}{
+		{
+			name: "leading slash",
+			href: "/api/pulp/default/api/v3/tasks/abc/",
+			want: "api/pulp/default/api/v3/tasks/abc/",
+		},
+		{
+			name: "no leading slash",
+			href: "api/pulp/default/api/v3/tasks/abc/",
+			want: "api/pulp/default/api/v3/tasks/abc/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizePulpHref(tt.href); got != tt.want {
+				t.Fatalf("normalizePulpHref() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/zestwrapper/maven.go
+++ b/internal/zestwrapper/maven.go
@@ -1,0 +1,175 @@
+package zestwrapper
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/content-services/tang/internal/config"
+	zest "github.com/content-services/zest/release/v2026"
+)
+
+func NewMavenZest(ctx context.Context, server config.Server) MavenZest {
+	ctx2 := context.WithValue(ctx, zest.ContextServerIndex, 0)
+	timeout := 120 * time.Second
+	transport := &http.Transport{ResponseHeaderTimeout: timeout}
+	httpClient := http.Client{Transport: transport, Timeout: timeout}
+
+	pulpConfig := zest.NewConfiguration()
+	pulpConfig.HTTPClient = &httpClient
+	pulpConfig.Servers = zest.ServerConfigurations{zest.ServerConfiguration{
+		URL: server.Url,
+	}}
+	ctx2 = context.WithValue(ctx2, zest.ContextBasicAuth, zest.BasicAuth{
+		UserName: server.Username,
+		Password: server.Password,
+	})
+
+	return MavenZest{
+		client:     zest.NewAPIClient(pulpConfig),
+		ctx:        ctx2,
+		httpClient: &httpClient,
+	}
+}
+
+type MavenZest struct {
+	client     *zest.APIClient
+	ctx        context.Context
+	httpClient *http.Client
+}
+
+func (m *MavenZest) LookupOrCreateDomain(name string) (string, error) {
+	d, err := m.LookupDomain(name)
+	if err != nil {
+		return "", err
+	}
+	if d != "" {
+		return d, nil
+	}
+
+	localStorage := zest.STORAGECLASSENUM_PULPCORE_APP_MODELS_STORAGE_FILE_SYSTEM
+	domain := *zest.NewDomain(name, localStorage, map[string]interface{}{
+		"location": fmt.Sprintf("/var/lib/pulp/%v/", name),
+	})
+	domainResp, resp, err := m.client.DomainsAPI.DomainsCreate(m.ctx, DefaultDomain).Domain(domain).Execute()
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+	return *domainResp.PulpHref, nil
+}
+
+func (m *MavenZest) LookupDomain(name string) (string, error) {
+	list, resp, err := m.client.DomainsAPI.DomainsList(m.ctx, DefaultDomain).Name(name).Execute()
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if len(list.Results) == 0 {
+		return "", nil
+	}
+	if list.Results[0].PulpHref == nil {
+		return "", fmt.Errorf("unexpectedly got a nil href for domain %v", name)
+	}
+	return *list.Results[0].PulpHref, nil
+}
+
+// CreateRepository creates a Maven remote, repository, and distribution for pull-through caching.
+func (m *MavenZest) CreateRepository(domain, name, remoteURL, distributionBasePath string) (repoHref string, remoteHref string, err error) {
+	mavenRemote := zest.NewMavenMavenRemote(name, remoteURL)
+
+	remoteResponse, httpResp, err := m.client.RemotesMavenAPI.RemotesMavenMavenCreate(m.ctx, domain).
+		MavenMavenRemote(*mavenRemote).Execute()
+	if err != nil {
+		return "", "", err
+	}
+	defer httpResp.Body.Close()
+
+	mavenRepository := zest.NewMavenMavenRepository(name)
+	if remoteResponse.PulpHref != nil {
+		mavenRepository.SetRemote(*remoteResponse.PulpHref)
+	}
+
+	repoResponse, httpResp, err := m.client.RepositoriesMavenAPI.RepositoriesMavenMavenCreate(m.ctx, domain).
+		MavenMavenRepository(*mavenRepository).Execute()
+	if err != nil {
+		return "", "", err
+	}
+	defer httpResp.Body.Close()
+
+	distribution := zest.NewMavenMavenDistribution(distributionBasePath, name)
+	distribution.SetRemote(*remoteResponse.PulpHref)
+	distribution.SetRepository(*repoResponse.PulpHref)
+
+	distResp, httpResp, err := m.client.DistributionsMavenAPI.DistributionsMavenMavenCreate(m.ctx, domain).
+		MavenMavenDistribution(*distribution).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	if _, err := m.PollTask(distResp.Task); err != nil {
+		return "", "", err
+	}
+
+	return *repoResponse.PulpHref, *remoteResponse.PulpHref, nil
+}
+
+// FetchArtifact triggers pull-through caching for an artifact path via the content app.
+func (m *MavenZest) FetchArtifact(contentOrigin, domain, distributionBasePath, artifactPath string) error {
+	artifactPath = strings.TrimPrefix(artifactPath, "/")
+	url := fmt.Sprintf("%s/pulp/content/%s/%s/%s", strings.TrimRight(contentOrigin, "/"), domain, distributionBasePath, artifactPath)
+
+	resp, err := m.httpClient.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("fetch artifact %s: %s", url, resp.Status)
+	}
+	return nil
+}
+
+// AddCachedContent adds pull-through cached Maven content into the repository.
+func (m *MavenZest) AddCachedContent(repoHref, remoteHref string) (string, error) {
+	addCached := zest.NewRepositoryAddCachedContent()
+	addCached.SetRemote(remoteHref)
+
+	resp, httpResp, err := m.client.RepositoriesMavenAPI.RepositoriesMavenMavenAddCachedContent(m.ctx, normalizePulpHref(repoHref)).
+		RepositoryAddCachedContent(*addCached).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+	return resp.Task, nil
+}
+
+func (m *MavenZest) PollTask(taskHref string) (*zest.TaskResponse, error) {
+	rpmZest := RpmZest{client: m.client, ctx: m.ctx}
+	return rpmZest.PollTask(taskHref)
+}
+
+func (m *MavenZest) GetMavenRepositoryByName(domain, name string) (*zest.MavenMavenRepositoryResponse, error) {
+	resp, httpResp, err := m.client.RepositoriesMavenAPI.RepositoriesMavenMavenList(m.ctx, domain).Name(name).Execute()
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	results := resp.GetResults()
+	if len(results) > 0 {
+		return &results[0], nil
+	}
+	return nil, nil
+}

--- a/internal/zestwrapper/python.go
+++ b/internal/zestwrapper/python.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/content-services/tang/internal/config"
-	zest "github.com/content-services/zest/release/v2024"
+	zest "github.com/content-services/zest/release/v2026"
 )
 
 func NewPythonZest(ctx context.Context, server config.Server) PythonZest {
@@ -113,7 +113,7 @@ func (p *PythonZest) SyncPythonRepository(repoHref, remoteHref string) (string, 
 	mirror := true
 	syncURL.SetMirror(mirror)
 
-	resp, httpResp, err := p.client.RepositoriesPythonAPI.RepositoriesPythonPythonSync(p.ctx, repoHref).
+	resp, httpResp, err := p.client.RepositoriesPythonAPI.RepositoriesPythonPythonSync(p.ctx, normalizePulpHref(repoHref)).
 		RepositorySyncURL(*syncURL).Execute()
 	if httpResp != nil {
 		defer httpResp.Body.Close()

--- a/internal/zestwrapper/rpm.go
+++ b/internal/zestwrapper/rpm.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/content-services/tang/internal/config"
-	zest "github.com/content-services/zest/release/v2024"
+	zest "github.com/content-services/zest/release/v2026"
 	"golang.org/x/exp/slices"
 )
 
@@ -102,7 +102,6 @@ func (r *RpmZest) CreateRepository(domain, name, url string) (repoHref string, r
 	defer httpResp.Body.Close()
 
 	rpmRpmRepository := *zest.NewRpmRpmRepository(name)
-	rpmRpmRepository.PackageSigningFingerprint = nil
 	if remoteResponse.PulpHref != nil {
 		rpmRpmRepository.SetRemote(*remoteResponse.PulpHref)
 	}
@@ -118,7 +117,7 @@ func (r *RpmZest) CreateRepository(domain, name, url string) (repoHref string, r
 }
 
 func (r *RpmZest) UpdateRemote(remoteHref string, url string) error {
-	_, httpResp, err := r.client.RemotesRpmAPI.RemotesRpmRpmPartialUpdate(r.ctx, remoteHref).PatchedrpmRpmRemote(zest.PatchedrpmRpmRemote{Url: &url}).Execute()
+	_, httpResp, err := r.client.RemotesRpmAPI.RemotesRpmRpmPartialUpdate(r.ctx, normalizePulpHref(remoteHref)).PatchedrpmRpmRemote(zest.PatchedrpmRpmRemote{Url: &url}).Execute()
 	if httpResp != nil {
 		defer httpResp.Body.Close()
 	}
@@ -133,7 +132,7 @@ func (r *RpmZest) SyncRpmRepository(rpmRpmRepositoryHref string, remoteHref stri
 	rpmRepositoryHref.SetRemote(remoteHref)
 	rpmRepositoryHref.SetSyncPolicy(zest.SYNCPOLICYENUM_MIRROR_CONTENT_ONLY)
 
-	resp, httpResp, err := r.client.RepositoriesRpmAPI.RepositoriesRpmRpmSync(r.ctx, rpmRpmRepositoryHref).
+	resp, httpResp, err := r.client.RepositoriesRpmAPI.RepositoriesRpmRpmSync(r.ctx, normalizePulpHref(rpmRpmRepositoryHref)).
 		RpmRepositorySyncURL(rpmRepositoryHref).Execute()
 	defer httpResp.Body.Close()
 	if err != nil {
@@ -144,7 +143,7 @@ func (r *RpmZest) SyncRpmRepository(rpmRpmRepositoryHref string, remoteHref stri
 
 // GetTask Fetch a pulp task
 func (r *RpmZest) GetTask(taskHref string) (zest.TaskResponse, error) {
-	task, httpResp, err := r.client.TasksAPI.TasksRead(r.ctx, taskHref).Execute()
+	task, httpResp, err := r.client.TasksAPI.TasksRead(r.ctx, normalizePulpHref(taskHref)).Execute()
 
 	if err != nil {
 		return zest.TaskResponse{}, err

--- a/pkg/tangy/maven_test.go
+++ b/pkg/tangy/maven_test.go
@@ -1,0 +1,166 @@
+package tangy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRepositoryHref(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		href    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid maven repository href",
+			href: "/api/pulp/default/api/v3/repositories/maven/maven/018c1c95-4281-76eb-b277-842cbad524f4/",
+			want: "018c1c95-4281-76eb-b277-842cbad524f4",
+		},
+		{
+			name: "valid href without trailing slash",
+			href: "/api/pulp/default/api/v3/repositories/maven/maven/018c1c95-4281-76eb-b277-842cbad524f4",
+			want: "018c1c95-4281-76eb-b277-842cbad524f4",
+		},
+		{
+			name:    "invalid href",
+			href:    "/api/pulp/default/api/v3/repositories/maven/",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseRepositoryHref(tt.href)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractRelease(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "release suffix in pom filename",
+			filename: "smallrye-mutiny-vertx-core-3.16.0.rhlw-3002.pom",
+			want:     "rhlw-3002",
+		},
+		{
+			name:     "plain pom filename",
+			filename: "junit-4.13.2.pom",
+			want:     "",
+		},
+		{
+			name:     "empty filename",
+			filename: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, extractRelease(tt.filename))
+		})
+	}
+}
+
+func TestMockTangyMavenPackageList(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/maven/maven/018c1c95-4281-76eb-b277-842cbad524f4/"
+	pageOpts := PageOptions{Offset: 0, Limit: 10}
+	filterOpts := MavenPackageListFilters{Search: "junit"}
+
+	expected := MavenPackageListResponse{
+		Results: []MavenPackageListItem{
+			{
+				GroupID:    "junit",
+				ArtifactID: "junit",
+				Versions:   []string{"4.13.2"},
+				LatestReleases: []MavenReleaseInfo{
+					{Version: "4.13.2", Release: "", CreatedAt: "2024-01-01T12:00:00Z"},
+				},
+			},
+		},
+		Total:  1,
+		Limit:  10,
+		Offset: 0,
+	}
+
+	mockTangy.On("MavenPackageList", ctx, repoHref, filterOpts, pageOpts).Return(expected, nil)
+
+	got, err := mockTangy.MavenPackageList(ctx, repoHref, filterOpts, pageOpts)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestMockTangyMavenBuildList(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/maven/maven/018c1c95-4281-76eb-b277-842cbad524f4/"
+	pageOpts := PageOptions{Offset: 0, Limit: 10}
+
+	expected := MavenBuildListResponse{
+		Results: []MavenBuildListItem{
+			{
+				GroupID:    "junit",
+				ArtifactID: "junit",
+				Version:    "4.13.2",
+				Release:    "",
+				Filename:   "junit-4.13.2.pom",
+				CreatedAt:  "2024-01-01T12:00:00Z",
+			},
+		},
+		Total:  1,
+		Limit:  10,
+		Offset: 0,
+	}
+
+	mockTangy.On("MavenBuildList", ctx, repoHref, "junit", "junit", "4.13.2", pageOpts).Return(expected, nil)
+
+	got, err := mockTangy.MavenBuildList(ctx, repoHref, "junit", "junit", "4.13.2", pageOpts)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestMockTangyMavenRepositoryMetrics(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/maven/maven/018c1c95-4281-76eb-b277-842cbad524f4/"
+
+	expected := MavenRepositoryMetrics{
+		PackageCount: 1,
+		BuildCount:   1,
+	}
+
+	mockTangy.On("MavenRepositoryMetrics", ctx, repoHref).Return(expected, nil)
+
+	got, err := mockTangy.MavenRepositoryMetrics(ctx, repoHref)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}

--- a/pkg/tangy/queries_test.go
+++ b/pkg/tangy/queries_test.go
@@ -1,0 +1,84 @@
+package tangy
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContentIdsInVersionNew(t *testing.T) {
+	t.Parallel()
+
+	args := pgx.NamedArgs{}
+	query := contentIdsInVersionNew(testRepoVersionUUID, 3, &args)
+
+	assert.Contains(t, query, "crv.repository_id = @repoName")
+	assert.Contains(t, query, "crv.number = @versionNum")
+	assert.Contains(t, query, "crv.content_ids IS NOT NULL")
+	require.Len(t, args, 2)
+	assert.Contains(t, namedArgValues(args), testRepoVersionUUID)
+	assert.Contains(t, namedArgValues(args), 3)
+}
+
+func TestContentIdsInVersionOld(t *testing.T) {
+	t.Parallel()
+
+	args := pgx.NamedArgs{}
+	query := contentIdsInVersionOld(testRepoVersionUUID, 3, &args)
+
+	assert.Contains(t, query, "crv.repository_id = @repoName")
+	assert.Contains(t, query, "crv.number <= @versionNum")
+	assert.Contains(t, query, "crv2.number IS NOT NULL")
+	require.Len(t, args, 2)
+	assert.Contains(t, namedArgValues(args), testRepoVersionUUID)
+	assert.Contains(t, namedArgValues(args), 3)
+}
+
+func TestContentIdsInVersionsNew(t *testing.T) {
+	t.Parallel()
+
+	args := pgx.NamedArgs{}
+	secondUUID := "019f3808-fcc2-716e-a7d3-e5a7ef1522a0"
+	repoVerMap := []ParsedRepoVersion{
+		{RepositoryUUID: testRepoVersionUUID, Version: 1},
+		{RepositoryUUID: secondUUID, Version: 2},
+	}
+
+	query := contentIdsInVersionsNew(repoVerMap, &args)
+
+	assert.Contains(t, query, "INNER JOIN core_repositoryversion crv ON (rp.content_ptr_id = ANY(crv.content_ids))")
+	assert.Contains(t, query, " OR ")
+	require.Len(t, args, 4)
+	values := namedArgValues(args)
+	assert.Contains(t, values, testRepoVersionUUID)
+	assert.Contains(t, values, secondUUID)
+	assert.Contains(t, values, 1)
+	assert.Contains(t, values, 2)
+}
+
+func TestContentIdsInVersionsOld(t *testing.T) {
+	t.Parallel()
+
+	args := pgx.NamedArgs{}
+	repoVerMap := []ParsedRepoVersion{
+		{RepositoryUUID: testRepoVersionUUID, Version: 1},
+	}
+
+	query := contentIdsInVersionsOld(repoVerMap, &args)
+
+	assert.Contains(t, query, "INNER JOIN core_repositorycontent crc on rp.content_ptr_id = crc.content_id")
+	assert.Contains(t, query, "LEFT OUTER JOIN core_repositoryversion crv2")
+	require.Len(t, args, 2)
+	assert.Contains(t, namedArgValues(args), testRepoVersionUUID)
+	assert.Contains(t, namedArgValues(args), 1)
+}
+
+func namedArgValues(args pgx.NamedArgs) []any {
+	values := make([]any, 0, len(args))
+	for _, value := range args {
+		values = append(values, value)
+	}
+	return values
+}

--- a/pkg/tangy/rpm.go
+++ b/pkg/tangy/rpm.go
@@ -505,7 +505,7 @@ func parseRepositoryVersionHrefsMap(hrefs []string) (mapping []ParsedRepoVersion
 	// /api/pulp/e1c6bee3/api/v3/repositories/rpm/rpm/018c1c95-4281-76eb-b277-842cbad524f4/versions/1/
 	for _, href := range hrefs {
 		splitHref := strings.Split(href, "/")
-		if len(splitHref) < 10 {
+		if len(splitHref) < 12 {
 			return mapping, fmt.Errorf("%v is not a valid href", splitHref)
 		}
 		id := splitHref[9]

--- a/pkg/tangy/rpm_test.go
+++ b/pkg/tangy/rpm_test.go
@@ -1,0 +1,153 @@
+package tangy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testRepoVersionUUID = "018c1c95-4281-76eb-b277-842cbad524f4"
+
+func TestParseRepositoryVersionHrefsMap(t *testing.T) {
+	t.Parallel()
+
+	validHref := "/api/pulp/default/api/v3/repositories/rpm/rpm/" + testRepoVersionUUID + "/versions/1/"
+
+	tests := []struct {
+		name    string
+		hrefs   []string
+		want    []ParsedRepoVersion
+		wantErr bool
+	}{
+		{
+			name:  "single valid href",
+			hrefs: []string{validHref},
+			want: []ParsedRepoVersion{{
+				RepositoryUUID: testRepoVersionUUID,
+				Version:        1,
+			}},
+		},
+		{
+			name: "multiple valid hrefs",
+			hrefs: []string{
+				validHref,
+				"/api/pulp/default/api/v3/repositories/rpm/rpm/" + testRepoVersionUUID + "/versions/2/",
+			},
+			want: []ParsedRepoVersion{
+				{RepositoryUUID: testRepoVersionUUID, Version: 1},
+				{RepositoryUUID: testRepoVersionUUID, Version: 2},
+			},
+		},
+		{
+			name:    "href too short",
+			hrefs:   []string{"/api/pulp/default/api/v3/repositories/rpm/rpm/"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid uuid",
+			hrefs:   []string{"/api/pulp/default/api/v3/repositories/rpm/rpm/not-a-uuid/versions/1/"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid version number",
+			hrefs:   []string{"/api/pulp/default/api/v3/repositories/rpm/rpm/" + testRepoVersionUUID + "/versions/x/"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseRepositoryVersionHrefsMap(tt.hrefs)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParsePackages(t *testing.T) {
+	t.Parallel()
+
+	got, err := parsePackages([]map[string]any{
+		{"name": "kernel"},
+		{"name": "bash"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"kernel", "bash"}, got)
+
+	_, err = parsePackages([]map[string]any{
+		{"name": 123},
+	})
+	require.Error(t, err)
+}
+
+func TestUnionSlices(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"a", "b", "c"}, unionSlices([]string{"a", "b"}, []string{"b", "c"}))
+	assert.Equal(t, []int{1, 2}, unionSlices([]int{1}, []int{2}))
+	assert.Empty(t, unionSlices([]string{}, []string{}))
+}
+
+func TestContainsString(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, containsString([]string{"kernel", "bash"}, "kernel"))
+	assert.False(t, containsString([]string{"kernel", "bash"}, "vim"))
+	assert.False(t, containsString(nil, "kernel"))
+}
+
+func TestMockTangyRpmRepositoryVersionPackageList(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	href := "/api/pulp/default/api/v3/repositories/rpm/rpm/" + testRepoVersionUUID + "/versions/1/"
+	filterOpts := RpmListFilters{Name: "kernel"}
+	pageOpts := PageOptions{Offset: 0, Limit: 20}
+
+	expected := []RpmListItem{
+		{
+			Id:      "pkg-1",
+			Name:    "kernel",
+			Arch:    "x86_64",
+			Version: "6.1.0",
+			Release: "1",
+			Epoch:   "0",
+			Summary: "The Linux kernel",
+		},
+	}
+
+	mockTangy.On("RpmRepositoryVersionPackageList", ctx, []string{href}, filterOpts, pageOpts).Return(expected, 1, nil)
+
+	got, total, err := mockTangy.RpmRepositoryVersionPackageList(ctx, []string{href}, filterOpts, pageOpts)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+	assert.Equal(t, 1, total)
+}
+
+func TestMockTangyRpmRepositoryVersionPackageSearch(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	href := "/api/pulp/default/api/v3/repositories/rpm/rpm/" + testRepoVersionUUID + "/versions/1/"
+
+	expected := []RpmPackageSearch{
+		{Name: "kernel", Summary: "The Linux kernel"},
+	}
+
+	mockTangy.On("RpmRepositoryVersionPackageSearch", ctx, []string{href}, "kern", 100).Return(expected, nil)
+
+	got, err := mockTangy.RpmRepositoryVersionPackageSearch(ctx, []string{href}, "kern", 100)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+}


### PR DESCRIPTION
This is a prerequisite for the NPM packages support - it needs zest update.

This PR:
- Upgrades `zest` to `v2026` and fixes Pulp `href` normalization for sync/task polling
- Adds `Maven` `zestwrapper`, integration tests, and `Maven`/`RPM`/`queries` unit tests
- Fixes RPM version `href` bounds check