### PR TITLE
HMS-10984: add endpoint for repo stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ buildResponse, err := t.MavenBuildList(context.Background(), repositoryHref, "or
 if err != nil {
   return err
 }
+
+// Use Tangy to get package and build counts for a Python repository
+pythonMetrics, err := t.PythonRepositoryMetrics(context.Background(), repositoryHref)
+if err != nil {
+  return err
+}
+
+// Use Tangy to get package and build counts for a Maven repository
+mavenMetrics, err := t.MavenRepositoryMetrics(context.Background(), repositoryHref)
+if err != nil {
+  return err
+}
 ```
 See example.go for a complete RPM example.
 
@@ -90,9 +102,11 @@ See example.go for a complete RPM example.
 Python support queries the `python_pythonpackagecontent` table. Each row is one installable distribution file (wheel, sdist, etc.).
 
 - **`PythonPackageList`** — lists packages in the latest repository version, grouped by `name_normalized`, with all versions and `latest_versions` (most recent `pulp_created` per version). Supports optional `Search` filter on `name` or `name_normalized`. Pagination is done in SQL.
+- **`PythonBuildList`** — lists builds (`name_normalized` + `version` pairs) in the latest repository version, optionally filtered by `name_normalized` and `version`. Pagination is done in SQL.
+- **`PythonRepositoryMetrics`** — returns `package_count` (distinct `name_normalized`) and `build_count` (distinct `name_normalized` + `version` pairs) for the latest repository version.
 - **`PythonDistributionList`** — lists distribution files for a given `name_normalized` and `version`. Pagination is done in SQL.
 - **`PythonPackageGet`** — returns package metadata for a given `name_normalized` and `version`, plus all other versions available in the repository and all distribution files for that version. Metadata is taken from one representative distribution (sdist preferred). Returns `ErrPythonPackageNotFound` when the package version is not in the repository.
-- **`PythonPackageVersionsGet`** — returns metadata for every version of a given `name_normalized`, each entry matching `PythonPackageGet` for that version. Returns `ErrPythonPackageNotFound` when the package is not in the repository.
+- **`PythonPackageVersionsGet`** — returns metadata for every version of a given `name_normalized`, each entry matching `PythonPackageGet` for that version. Requires `name_normalized`. Returns `ErrPythonPackageNotFound` when the package is not in the repository.
 
 Repository href format:
 

--- a/internal/test/integration/python_test.go
+++ b/internal/test/integration/python_test.go
@@ -2,8 +2,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/content-services/tang/internal/config"
@@ -281,44 +279,58 @@ func (p *PythonSuite) TestPythonPackageVersionsGetEmptyHref() {
 }
 
 func (p *PythonSuite) TestPythonPackageVersionsGetEmptyNameNormalized() {
-	repoHref, remoteHref, err := p.client.CreateRepository(
-		p.domainName,
-		fmt.Sprintf("%s-%v", testPythonMultiVersionRepoName, rand.Int()),
-		testPythonRepoURL,
-		[]string{testPythonIncludes, testPythonMultiVersionPackage},
-		0,
-	)
-	require.NoError(p.T(), err)
-
-	syncTask, err := p.client.SyncPythonRepository(repoHref, remoteHref)
-	require.NoError(p.T(), err)
-
-	_, err = p.client.PollTask(syncTask)
-	require.NoError(p.T(), err)
-
-	// Call with empty nameNormalized - should return all packages in the repository
-	details, err := p.tangy.PythonPackageVersionsGet(
+	_, err := p.tangy.PythonPackageVersionsGet(
 		context.Background(),
-		repoHref,
+		p.repositoryHref,
 		"",
 	)
-	require.NoError(p.T(), err)
-	require.NotEmpty(p.T(), details, "Should return packages when nameNormalized is empty")
+	require.Error(p.T(), err)
+	assert.ErrorIs(p.T(), err, tangy.ErrPythonNameNormalizedRequired)
+}
 
-	// Verify that we got actual package data back
-	for _, detail := range details {
-		assert.NotEmpty(p.T(), detail.NameNormalized)
-		assert.NotEmpty(p.T(), detail.Name)
-		assert.NotEmpty(p.T(), detail.Version)
-	}
-
-	singleDetails, err := p.tangy.PythonPackageVersionsGet(
+func (p *PythonSuite) TestPythonBuildList() {
+	response, err := p.tangy.PythonBuildList(
 		context.Background(),
-		repoHref,
-		testPythonMultiVersionPackage,
+		p.repositoryHref,
+		"",
+		"",
+		tangy.PageOptions{Offset: 0, Limit: 10},
 	)
-	assert.NoError(p.T(), err)
-	assert.Greater(p.T(), len(details), len(singleDetails))
+	require.NoError(p.T(), err)
+	require.NotEmpty(p.T(), response.Results)
+	assert.Equal(p.T(), 1, response.Total)
+	assert.Equal(p.T(), 10, response.Limit)
+
+	build := response.Results[0]
+	assert.Equal(p.T(), "shelf-reader", build.NameNormalized)
+	assert.Equal(p.T(), "0.1", build.Version)
+	assert.NotEmpty(p.T(), build.Name)
+	assert.NotEmpty(p.T(), build.CreatedAt)
+
+	filtered, err := p.tangy.PythonBuildList(
+		context.Background(),
+		p.repositoryHref,
+		"shelf-reader",
+		"0.1",
+		tangy.PageOptions{Offset: 0, Limit: 10},
+	)
+	require.NoError(p.T(), err)
+	require.Len(p.T(), filtered.Results, 1)
+	assert.Equal(p.T(), 1, filtered.Total)
+}
+
+func (p *PythonSuite) TestPythonRepositoryMetrics() {
+	metrics, err := p.tangy.PythonRepositoryMetrics(context.Background(), p.repositoryHref)
+	require.NoError(p.T(), err)
+	assert.Equal(p.T(), 1, metrics.PackageCount)
+	assert.Equal(p.T(), 1, metrics.BuildCount)
+}
+
+func (p *PythonSuite) TestPythonRepositoryMetricsEmptyHref() {
+	metrics, err := p.tangy.PythonRepositoryMetrics(context.Background(), "")
+	require.NoError(p.T(), err)
+	assert.Zero(p.T(), metrics.PackageCount)
+	assert.Zero(p.T(), metrics.BuildCount)
 }
 
 func (p *PythonSuite) TestPythonPackageGetNotFound() {

--- a/pkg/tangy/interface.go
+++ b/pkg/tangy/interface.go
@@ -69,8 +69,11 @@ type Tangy interface {
 	PythonDistributionList(ctx context.Context, repositoryHref, nameNormalized, version string, pageOpts PageOptions) (PythonDistributionListResponse, error)
 	PythonPackageGet(ctx context.Context, repositoryHref, nameNormalized, version string) (PythonPackageDetail, error)
 	PythonPackageVersionsGet(ctx context.Context, repositoryHref, nameNormalized string) ([]PythonPackageDetail, error)
+	PythonBuildList(ctx context.Context, repositoryHref, nameNormalized, version string, pageOpts PageOptions) (PythonBuildListResponse, error)
+	PythonRepositoryMetrics(ctx context.Context, repositoryHref string) (PythonRepositoryMetrics, error)
 	MavenPackageList(ctx context.Context, repositoryHref string, filterOpts MavenPackageListFilters, pageOpts PageOptions) (MavenPackageListResponse, error)
 	MavenBuildList(ctx context.Context, repositoryHref, groupID, artifactID, version string, pageOpts PageOptions) (MavenBuildListResponse, error)
+	MavenRepositoryMetrics(ctx context.Context, repositoryHref string) (MavenRepositoryMetrics, error)
 	Close()
 }
 

--- a/pkg/tangy/maven.go
+++ b/pkg/tangy/maven.go
@@ -52,6 +52,11 @@ type MavenBuildListResponse struct {
 	Offset  int                  `json:"offset"`
 }
 
+type MavenRepositoryMetrics struct {
+	PackageCount int `json:"package_count"`
+	BuildCount   int `json:"build_count"`
+}
+
 type mavenArtifactQueryResult struct {
 	GroupID    string
 	ArtifactID string
@@ -402,4 +407,59 @@ func (t *tangyImpl) MavenBuildList(ctx context.Context, repositoryHref, groupID,
 		Limit:   pageOpts.Limit,
 		Offset:  pageOpts.Offset,
 	}, nil
+}
+
+// MavenRepositoryMetrics returns package and build counts for the latest version of a repository.
+// Packages are distinct group_id/artifact_id pairs; builds are .pom artifacts.
+func (t *tangyImpl) MavenRepositoryMetrics(ctx context.Context, repositoryHref string) (MavenRepositoryMetrics, error) {
+	if repositoryHref == "" {
+		return MavenRepositoryMetrics{}, nil
+	}
+
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return MavenRepositoryMetrics{}, err
+	}
+	defer conn.Release()
+
+	repoUUID, err := parseRepositoryHref(repositoryHref)
+	if err != nil {
+		return MavenRepositoryMetrics{}, fmt.Errorf("error parsing repository href: %w", err)
+	}
+
+	latestVersion, err := getLatestRepositoryVersion(ctx, conn, repoUUID)
+	if err != nil {
+		return MavenRepositoryMetrics{}, fmt.Errorf("error getting latest repository version: %w", err)
+	}
+
+	repoVerMap := []ParsedRepoVersion{{
+		RepositoryUUID: repoUUID,
+		Version:        latestVersion,
+	}}
+
+	args := pgx.NamedArgs{}
+	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
+	if err != nil {
+		return MavenRepositoryMetrics{}, err
+	}
+
+	pomFilter := ` AND rp.filename LIKE '%.pom'`
+	artifactFrom := `
+		FROM maven_mavenartifact rp
+	` + innerUnion + pomFilter
+
+	metricsQuery := `
+		SELECT
+			(SELECT COUNT(DISTINCT (rp.group_id, rp.artifact_id))
+			` + artifactFrom + `) AS package_count,
+			(SELECT COUNT(*)
+			` + artifactFrom + `) AS build_count`
+
+	var metrics MavenRepositoryMetrics
+	err = conn.QueryRow(ctx, metricsQuery, args).Scan(&metrics.PackageCount, &metrics.BuildCount)
+	if err != nil {
+		return MavenRepositoryMetrics{}, err
+	}
+
+	return metrics, nil
 }

--- a/pkg/tangy/python.go
+++ b/pkg/tangy/python.go
@@ -36,6 +36,25 @@ type PythonPackageListFilters struct {
 	Search string
 }
 
+type PythonBuildListItem struct {
+	Name           string `json:"name"`
+	NameNormalized string `json:"name_normalized"`
+	Version        string `json:"version"`
+	CreatedAt      string `json:"created_at"`
+}
+
+type PythonBuildListResponse struct {
+	Results []PythonBuildListItem `json:"results"`
+	Total   int                   `json:"total"`
+	Limit   int                   `json:"limit"`
+	Offset  int                   `json:"offset"`
+}
+
+type PythonRepositoryMetrics struct {
+	PackageCount int `json:"package_count"`
+	BuildCount   int `json:"build_count"`
+}
+
 type PythonDistributionListItem struct {
 	Name           string `json:"name"`
 	NameNormalized string `json:"name_normalized"`
@@ -83,11 +102,21 @@ type PythonPackageDetail struct {
 	Distributions          []PythonDistributionListItem `json:"distributions"`
 }
 
-var ErrPythonPackageNotFound = errors.New("python package not found")
+var (
+	ErrPythonPackageNotFound        = errors.New("python package not found")
+	ErrPythonNameNormalizedRequired = errors.New("name_normalized is required")
+)
 
 type pythonPackageVersionRow struct {
 	NameNormalized string
 	Name           string
+	Version        string
+	CreatedAt      time.Time
+}
+
+type pythonBuildRow struct {
+	Name           string
+	NameNormalized string
 	Version        string
 	CreatedAt      time.Time
 }
@@ -334,13 +363,15 @@ func (t *tangyImpl) PythonPackageGet(ctx context.Context, repositoryHref, nameNo
 	return pythonPackageDetailFromRow(row, latestVersions, pythonDistributionRowsToItems(distributions)), nil
 }
 
-// PythonPackageVersionsGet returns metadata for every version of a package (optionally filtered by name_normalized)
-// from the latest version of a repository. Metadata for each version is taken from one
-// representative distribution (sdist preferred, then most recently synced).
-// If nameNormalized is empty, returns all packages in the repository.
+// PythonPackageVersionsGet returns metadata for every version of a package from the latest version
+// of a repository. Metadata for each version is taken from one representative distribution
+// (sdist preferred, then most recently synced).
 func (t *tangyImpl) PythonPackageVersionsGet(ctx context.Context, repositoryHref, nameNormalized string) ([]PythonPackageDetail, error) {
 	if repositoryHref == "" {
 		return nil, nil
+	}
+	if nameNormalized == "" {
+		return nil, ErrPythonNameNormalizedRequired
 	}
 
 	conn, innerUnion, args, err := t.preparePythonPackageQuery(ctx, repositoryHref, nameNormalized)
@@ -354,10 +385,7 @@ func (t *tangyImpl) PythonPackageVersionsGet(ctx context.Context, repositoryHref
 		return nil, err
 	}
 	if len(detailRows) == 0 {
-		if nameNormalized != "" {
-			return nil, fmt.Errorf("%w: %s", ErrPythonPackageNotFound, nameNormalized)
-		}
-		return []PythonPackageDetail{}, nil
+		return nil, fmt.Errorf("%w: %s", ErrPythonPackageNotFound, nameNormalized)
 	}
 
 	latestVersions, err := parsePythonLatestVersionsJSON(detailRows[0].LatestVersionsJSON)
@@ -384,6 +412,169 @@ func (t *tangyImpl) PythonPackageVersionsGet(ctx context.Context, repositoryHref
 	}
 
 	return results, nil
+}
+
+// PythonBuildList lists all Python package builds (name_normalized + version pairs), optionally
+// filtered by name_normalized and version, from the latest version of a repository.
+func (t *tangyImpl) PythonBuildList(ctx context.Context, repositoryHref, nameNormalized, version string, pageOpts PageOptions) (PythonBuildListResponse, error) {
+	if repositoryHref == "" {
+		return PythonBuildListResponse{}, nil
+	}
+
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return PythonBuildListResponse{}, err
+	}
+	defer conn.Release()
+
+	if pageOpts.Limit == 0 {
+		pageOpts.Limit = DefaultLimit
+	}
+
+	repoUUID, err := parsePythonRepositoryHref(repositoryHref)
+	if err != nil {
+		return PythonBuildListResponse{}, fmt.Errorf("error parsing repository href: %w", err)
+	}
+
+	latestVersion, err := getLatestPythonRepositoryVersion(ctx, conn, repoUUID)
+	if err != nil {
+		return PythonBuildListResponse{}, fmt.Errorf("error getting latest repository version: %w", err)
+	}
+
+	repoVerMap := []ParsedRepoVersion{{
+		RepositoryUUID: repoUUID,
+		Version:        latestVersion,
+	}}
+
+	args := pgx.NamedArgs{}
+
+	var whereClause string
+	if nameNormalized != "" {
+		args["name_normalized"] = nameNormalized
+		whereClause += "\n\t\tAND rp.name_normalized = @name_normalized"
+	}
+	if version != "" {
+		args["version"] = version
+		whereClause += "\n\t\tAND rp.version = @version"
+	}
+
+	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
+	if err != nil {
+		return PythonBuildListResponse{}, err
+	}
+
+	buildFrom := `
+		FROM python_pythonpackagecontent rp
+		INNER JOIN core_content cc ON rp.content_ptr_id = cc.pulp_id
+	` + innerUnion + whereClause
+
+	countQuery := `
+		SELECT COUNT(*)
+		FROM (
+			SELECT rp.name_normalized, rp.version
+		` + buildFrom + `
+			GROUP BY rp.name_normalized, rp.version
+		) builds`
+
+	var countTotal int
+	err = conn.QueryRow(ctx, countQuery, args).Scan(&countTotal)
+	if err != nil {
+		return PythonBuildListResponse{}, err
+	}
+
+	args["limit"] = pageOpts.Limit
+	args["offset"] = pageOpts.Offset
+
+	query := `
+		SELECT MIN(rp.name) AS name, rp.name_normalized, rp.version, MAX(cc.pulp_created) AS created_at
+	` + buildFrom + `
+		GROUP BY rp.name_normalized, rp.version
+		ORDER BY created_at DESC
+		LIMIT @limit OFFSET @offset`
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return PythonBuildListResponse{}, err
+	}
+
+	buildRows, err := pgx.CollectRows(rows, pgx.RowToStructByName[pythonBuildRow])
+	if err != nil {
+		return PythonBuildListResponse{}, err
+	}
+
+	results := make([]PythonBuildListItem, len(buildRows))
+	for i, row := range buildRows {
+		results[i] = PythonBuildListItem{
+			Name:           row.Name,
+			NameNormalized: row.NameNormalized,
+			Version:        row.Version,
+			CreatedAt:      row.CreatedAt.Format(time.RFC3339),
+		}
+	}
+
+	return PythonBuildListResponse{
+		Results: results,
+		Total:   countTotal,
+		Limit:   pageOpts.Limit,
+		Offset:  pageOpts.Offset,
+	}, nil
+}
+
+// PythonRepositoryMetrics returns package and build counts for the latest version of a repository.
+func (t *tangyImpl) PythonRepositoryMetrics(ctx context.Context, repositoryHref string) (PythonRepositoryMetrics, error) {
+	if repositoryHref == "" {
+		return PythonRepositoryMetrics{}, nil
+	}
+
+	conn, err := t.pool.Acquire(ctx)
+	if err != nil {
+		return PythonRepositoryMetrics{}, err
+	}
+	defer conn.Release()
+
+	repoUUID, err := parsePythonRepositoryHref(repositoryHref)
+	if err != nil {
+		return PythonRepositoryMetrics{}, fmt.Errorf("error parsing repository href: %w", err)
+	}
+
+	latestVersion, err := getLatestPythonRepositoryVersion(ctx, conn, repoUUID)
+	if err != nil {
+		return PythonRepositoryMetrics{}, fmt.Errorf("error getting latest repository version: %w", err)
+	}
+
+	repoVerMap := []ParsedRepoVersion{{
+		RepositoryUUID: repoUUID,
+		Version:        latestVersion,
+	}}
+
+	args := pgx.NamedArgs{}
+	innerUnion, err := contentIdsInVersions(ctx, conn, repoVerMap, &args)
+	if err != nil {
+		return PythonRepositoryMetrics{}, err
+	}
+
+	contentFrom := `
+		FROM python_pythonpackagecontent rp
+	` + innerUnion
+
+	metricsQuery := `
+		SELECT
+			(SELECT COUNT(DISTINCT rp.name_normalized)
+			` + contentFrom + `) AS package_count,
+			(SELECT COUNT(*)
+			 FROM (
+				SELECT 1
+				` + contentFrom + `
+				GROUP BY rp.name_normalized, rp.version
+			 ) builds) AS build_count`
+
+	var metrics PythonRepositoryMetrics
+	err = conn.QueryRow(ctx, metricsQuery, args).Scan(&metrics.PackageCount, &metrics.BuildCount)
+	if err != nil {
+		return PythonRepositoryMetrics{}, err
+	}
+
+	return metrics, nil
 }
 
 func (t *tangyImpl) preparePythonPackageQuery(ctx context.Context, repositoryHref, nameNormalized string) (*pgxpool.Conn, string, pgx.NamedArgs, error) {

--- a/pkg/tangy/python_test.go
+++ b/pkg/tangy/python_test.go
@@ -347,39 +347,59 @@ func TestMockTangyPythonPackageVersionsGetEmptyNameNormalized(t *testing.T) {
 	ctx := context.Background()
 	repoHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
 
-	// Expected result when calling with empty nameNormalized - should return multiple packages
-	expected := []PythonPackageDetail{
-		{
-			Name:           "Django",
-			NameNormalized: "django",
-			Version:        "4.2",
-			Summary:        "A high-level Python web framework",
-			LastUpdated:    "2023-01-01T12:00:00Z",
-			Versions:       []string{"4.2"},
-			LatestVersions: []PythonVersionInfo{
-				{Version: "4.2", CreatedAt: "2023-01-01T12:00:00Z"},
-			},
-		},
-		{
-			Name:           "Requests",
-			NameNormalized: "requests",
-			Version:        "2.31.0",
-			Summary:        "Python HTTP for Humans",
-			LastUpdated:    "2023-05-01T12:00:00Z",
-			Versions:       []string{"2.31.0"},
-			LatestVersions: []PythonVersionInfo{
-				{Version: "2.31.0", CreatedAt: "2023-05-01T12:00:00Z"},
-			},
-		},
-	}
-
-	// Mock the call with empty string for nameNormalized
-	mockTangy.On("PythonPackageVersionsGet", ctx, repoHref, "").Return(expected, nil)
+	mockTangy.On("PythonPackageVersionsGet", ctx, repoHref, "").Return(nil, ErrPythonNameNormalizedRequired)
 
 	got, err := mockTangy.PythonPackageVersionsGet(ctx, repoHref, "")
+	require.ErrorIs(t, err, ErrPythonNameNormalizedRequired)
+	assert.Nil(t, got)
+}
+
+func TestMockTangyPythonBuildList(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	pageOpts := PageOptions{Offset: 0, Limit: 10}
+
+	expected := PythonBuildListResponse{
+		Results: []PythonBuildListItem{
+			{
+				Name:           "Django",
+				NameNormalized: "django",
+				Version:        "5.0",
+				CreatedAt:      "2024-01-01T12:00:00Z",
+			},
+		},
+		Total:  1,
+		Limit:  10,
+		Offset: 0,
+	}
+
+	mockTangy.On("PythonBuildList", ctx, repoHref, "", "", pageOpts).Return(expected, nil)
+
+	got, err := mockTangy.PythonBuildList(ctx, repoHref, "", "", pageOpts)
 	require.NoError(t, err)
 	assert.Equal(t, expected, got)
-	assert.Len(t, got, 2, "Should return multiple packages when nameNormalized is empty")
+}
+
+func TestMockTangyPythonRepositoryMetrics(t *testing.T) {
+	t.Parallel()
+
+	mockTangy := NewMockTangy(t)
+	ctx := context.Background()
+	repoHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+
+	expected := PythonRepositoryMetrics{
+		PackageCount: 10,
+		BuildCount:   25,
+	}
+
+	mockTangy.On("PythonRepositoryMetrics", ctx, repoHref).Return(expected, nil)
+
+	got, err := mockTangy.PythonRepositoryMetrics(ctx, repoHref)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
 }
 
 func TestParsePythonJSONStringSlice(t *testing.T) {

--- a/pkg/tangy/tangy_mock.go
+++ b/pkg/tangy/tangy_mock.go
@@ -238,6 +238,156 @@ func (_c *MockTangy_MavenPackageList_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// MavenRepositoryMetrics provides a mock function for the type MockTangy
+func (_mock *MockTangy) MavenRepositoryMetrics(ctx context.Context, repositoryHref string) (MavenRepositoryMetrics, error) {
+	ret := _mock.Called(ctx, repositoryHref)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MavenRepositoryMetrics")
+	}
+
+	var r0 MavenRepositoryMetrics
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (MavenRepositoryMetrics, error)); ok {
+		return returnFunc(ctx, repositoryHref)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) MavenRepositoryMetrics); ok {
+		r0 = returnFunc(ctx, repositoryHref)
+	} else {
+		r0 = ret.Get(0).(MavenRepositoryMetrics)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, repositoryHref)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTangy_MavenRepositoryMetrics_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MavenRepositoryMetrics'
+type MockTangy_MavenRepositoryMetrics_Call struct {
+	*mock.Call
+}
+
+// MavenRepositoryMetrics is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repositoryHref string
+func (_e *MockTangy_Expecter) MavenRepositoryMetrics(ctx any, repositoryHref any) *MockTangy_MavenRepositoryMetrics_Call {
+	return &MockTangy_MavenRepositoryMetrics_Call{Call: _e.mock.On("MavenRepositoryMetrics", ctx, repositoryHref)}
+}
+
+func (_c *MockTangy_MavenRepositoryMetrics_Call) Run(run func(ctx context.Context, repositoryHref string)) *MockTangy_MavenRepositoryMetrics_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTangy_MavenRepositoryMetrics_Call) Return(mavenRepositoryMetrics MavenRepositoryMetrics, err error) *MockTangy_MavenRepositoryMetrics_Call {
+	_c.Call.Return(mavenRepositoryMetrics, err)
+	return _c
+}
+
+func (_c *MockTangy_MavenRepositoryMetrics_Call) RunAndReturn(run func(ctx context.Context, repositoryHref string) (MavenRepositoryMetrics, error)) *MockTangy_MavenRepositoryMetrics_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PythonBuildList provides a mock function for the type MockTangy
+func (_mock *MockTangy) PythonBuildList(ctx context.Context, repositoryHref string, nameNormalized string, version string, pageOpts PageOptions) (PythonBuildListResponse, error) {
+	ret := _mock.Called(ctx, repositoryHref, nameNormalized, version, pageOpts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PythonBuildList")
+	}
+
+	var r0 PythonBuildListResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, PageOptions) (PythonBuildListResponse, error)); ok {
+		return returnFunc(ctx, repositoryHref, nameNormalized, version, pageOpts)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, PageOptions) PythonBuildListResponse); ok {
+		r0 = returnFunc(ctx, repositoryHref, nameNormalized, version, pageOpts)
+	} else {
+		r0 = ret.Get(0).(PythonBuildListResponse)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, PageOptions) error); ok {
+		r1 = returnFunc(ctx, repositoryHref, nameNormalized, version, pageOpts)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTangy_PythonBuildList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PythonBuildList'
+type MockTangy_PythonBuildList_Call struct {
+	*mock.Call
+}
+
+// PythonBuildList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repositoryHref string
+//   - nameNormalized string
+//   - version string
+//   - pageOpts PageOptions
+func (_e *MockTangy_Expecter) PythonBuildList(ctx any, repositoryHref any, nameNormalized any, version any, pageOpts any) *MockTangy_PythonBuildList_Call {
+	return &MockTangy_PythonBuildList_Call{Call: _e.mock.On("PythonBuildList", ctx, repositoryHref, nameNormalized, version, pageOpts)}
+}
+
+func (_c *MockTangy_PythonBuildList_Call) Run(run func(ctx context.Context, repositoryHref string, nameNormalized string, version string, pageOpts PageOptions)) *MockTangy_PythonBuildList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 PageOptions
+		if args[4] != nil {
+			arg4 = args[4].(PageOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTangy_PythonBuildList_Call) Return(pythonBuildListResponse PythonBuildListResponse, err error) *MockTangy_PythonBuildList_Call {
+	_c.Call.Return(pythonBuildListResponse, err)
+	return _c
+}
+
+func (_c *MockTangy_PythonBuildList_Call) RunAndReturn(run func(ctx context.Context, repositoryHref string, nameNormalized string, version string, pageOpts PageOptions) (PythonBuildListResponse, error)) *MockTangy_PythonBuildList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PythonDistributionList provides a mock function for the type MockTangy
 func (_mock *MockTangy) PythonDistributionList(ctx context.Context, repositoryHref string, nameNormalized string, version string, pageOpts PageOptions) (PythonDistributionListResponse, error) {
 	ret := _mock.Called(ctx, repositoryHref, nameNormalized, version, pageOpts)
@@ -548,6 +698,72 @@ func (_c *MockTangy_PythonPackageVersionsGet_Call) Return(pythonPackageDetails [
 }
 
 func (_c *MockTangy_PythonPackageVersionsGet_Call) RunAndReturn(run func(ctx context.Context, repositoryHref string, nameNormalized string) ([]PythonPackageDetail, error)) *MockTangy_PythonPackageVersionsGet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PythonRepositoryMetrics provides a mock function for the type MockTangy
+func (_mock *MockTangy) PythonRepositoryMetrics(ctx context.Context, repositoryHref string) (PythonRepositoryMetrics, error) {
+	ret := _mock.Called(ctx, repositoryHref)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PythonRepositoryMetrics")
+	}
+
+	var r0 PythonRepositoryMetrics
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (PythonRepositoryMetrics, error)); ok {
+		return returnFunc(ctx, repositoryHref)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) PythonRepositoryMetrics); ok {
+		r0 = returnFunc(ctx, repositoryHref)
+	} else {
+		r0 = ret.Get(0).(PythonRepositoryMetrics)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, repositoryHref)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTangy_PythonRepositoryMetrics_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PythonRepositoryMetrics'
+type MockTangy_PythonRepositoryMetrics_Call struct {
+	*mock.Call
+}
+
+// PythonRepositoryMetrics is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repositoryHref string
+func (_e *MockTangy_Expecter) PythonRepositoryMetrics(ctx any, repositoryHref any) *MockTangy_PythonRepositoryMetrics_Call {
+	return &MockTangy_PythonRepositoryMetrics_Call{Call: _e.mock.On("PythonRepositoryMetrics", ctx, repositoryHref)}
+}
+
+func (_c *MockTangy_PythonRepositoryMetrics_Call) Run(run func(ctx context.Context, repositoryHref string)) *MockTangy_PythonRepositoryMetrics_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTangy_PythonRepositoryMetrics_Call) Return(pythonRepositoryMetrics PythonRepositoryMetrics, err error) *MockTangy_PythonRepositoryMetrics_Call {
+	_c.Call.Return(pythonRepositoryMetrics, err)
+	return _c
+}
+
+func (_c *MockTangy_PythonRepositoryMetrics_Call) RunAndReturn(run func(ctx context.Context, repositoryHref string) (PythonRepositoryMetrics, error)) *MockTangy_PythonRepositoryMetrics_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This PR:
- Adds `PythonRepositoryMetrics` and `MavenRepositoryMetrics` for package/build counts in one call
- Adds `PythonBuildList` for paginated `(name_normalized, version)` builds, mirroring `MavenBuildList`
- Requires `name_normalized` on `PythonPackageVersionsGet`; returns `ErrPythonNameNormalizedRequired` if empty
- Updates unit and integration tests; documents new Python APIs in `README.md`